### PR TITLE
feat: add fastlane deployment and fix news image caching

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,7 +90,18 @@ python news_tool/app.py
 ### Full pipeline
 
 ```bash
-python main.py
+python main.py                          # default: HTTP scrapper, 10 workers
+python main.py --workers 20             # increase parallelism
+python main.py --old-scrapper           # use Selenium scrapper (fallback, ~7x slower)
+python main.py --old-scrapper --workers 3
+```
+
+### Re-upload without re-scraping
+
+If `output/parser.json` is already up to date, skip the scraping steps:
+
+```bash
+python uploadparsetodb.py
 ```
 
 ### Individual steps
@@ -131,6 +142,21 @@ Create a `.env` file in the `backend/` directory:
 SUPABASE_URL=https://<project>.supabase.co
 SUPABASE_KEY=<anon_key>
 SUPABASE_SERVICE_KEY=<service_role_key>   # required for json2db clear_db and news_tool uploads
+
+# Optional – test database (used when .env_mode contains "test")
+TEST_SUPABASE_URL=https://<test-project>.supabase.co
+TEST_SUPABASE_KEY=<test_anon_key>
+TEST_SUPABASE_SERVICE_KEY=<test_service_role_key>
+TEST_DB_URL=postgresql://...              # for direct DB access in slow tests
+```
+
+### Switching between production and test database
+
+The file `.env_mode` controls which credentials are used:
+
+```bash
+echo "test" > .env_mode   # use TEST_SUPABASE_* credentials
+echo "prod" > .env_mode   # use SUPABASE_* credentials (default)
 ```
 
 ---

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -118,3 +118,7 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+# Fastlane & deploy keys
+android/planpm_deploy_key.json
+ios/Runner.ipa
+ios/Runner.app.dSYM.zip

--- a/frontend/android/Gemfile
+++ b/frontend/android/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/frontend/android/fastlane/Appfile
+++ b/frontend/android/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("/Users/piotrwittig/Coding/plan_pm/frontend/android/planpm_deploy_key.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+package_name("com.piotrwittig.plan_pm") # e.g. com.krausefx.app

--- a/frontend/android/fastlane/FASTLANE.md
+++ b/frontend/android/fastlane/FASTLANE.md
@@ -1,0 +1,84 @@
+# Fastlane – ściągawka
+
+## Struktura
+
+```
+android/
+├── Gemfile                  # zależność: gem "fastlane"
+├── fastlane/
+│   ├── Appfile              # package name + ścieżka do klucza Google Play
+│   └── Fastfile             # definicje lane'ów
+└── planpm_deploy_key.json   # klucz service account do Google Play API
+```
+
+## Konfiguracja (Appfile)
+
+```ruby
+json_key_file("android/planpm_deploy_key.json")
+package_name("com.piotrwittig.plan_pm")
+```
+
+## Dostępne lane'y
+
+| Lane | Komenda | Co robi |
+|---|---|---|
+| `test` | `fastlane test` | Uruchamia testy Gradle |
+| `beta` | `fastlane beta` | Buduje release APK + wysyła do Crashlytics |
+| `deploy` | `fastlane deploy` | Buduje release APK + wysyła do Google Play |
+
+## Typowy flow wdrożenia
+
+```bash
+# 1. Zbuduj AAB we Flutterze (z katalogu frontend/)
+flutter build appbundle --release
+
+# 2. Wejdź do katalogu android i odpal lane
+cd android
+bundle exec fastlane deploy
+```
+
+> Fastlane należy uruchamiać przez `bundle exec fastlane` (nie `fastlane` bezpośrednio),
+> żeby używał wersji z Gemfile.
+
+## Wgranie do Google Play – track'i
+
+`upload_to_play_store` domyślnie wgrywa na track `production`.
+Żeby wysłać na inny track, dodaj parametr:
+
+```ruby
+upload_to_play_store(track: "internal")   # internal testing
+upload_to_play_store(track: "alpha")
+upload_to_play_store(track: "beta")
+upload_to_play_store(track: "production") # domyślnie
+```
+
+Żeby wgrać AAB zamiast APK (zalecane przez Google Play):
+
+```ruby
+upload_to_play_store(
+  track: "internal",
+  aab: "../build/app/outputs/bundle/release/app-release.aab"
+)
+```
+
+## Klucz Google Play (`planpm_deploy_key.json`)
+
+- Service account JSON z Google Cloud Console
+- Musi mieć uprawnienia do Google Play Android Developer API
+- Nie commitować do publicznego repo
+- Ścieżka skonfigurowana w `Appfile`
+
+## Instalacja (jednorazowo)
+
+```bash
+cd android
+bundle install   # instaluje fastlane z Gemfile
+```
+
+## Przydatne komendy
+
+```bash
+bundle exec fastlane lanes          # lista wszystkich lane'ów
+bundle exec fastlane action <name>  # dokumentacja konkretnej akcji
+bundle exec fastlane env            # wyświetl zmienne środowiskowe
+```

--- a/frontend/android/fastlane/Fastfile
+++ b/frontend/android/fastlane/Fastfile
@@ -1,0 +1,31 @@
+default_platform(:android)
+
+platform :android do
+  desc "Deploy a new version to the Google Play"
+  lane :deploy do
+    # Build signed AAB via Flutter (from the frontend root)
+    sh("cd ../../ && flutter build appbundle --release")
+
+    upload_to_play_store(
+      track: "production",
+      aab: "../build/app/outputs/bundle/release/app-release.aab",
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+
+  desc "Promote internal build to production"
+  lane :promote do
+    upload_to_play_store(
+      track: "internal",
+      track_promote_to: "production",
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+end

--- a/frontend/ios/Gemfile
+++ b/frontend/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -330,9 +330,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -469,7 +473,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = UYTX3DLBWN;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -497,7 +501,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 17;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.piotrwittig.planPm.RunnerTests;
@@ -515,7 +519,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 17;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.piotrwittig.planPm.RunnerTests;
@@ -531,7 +535,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 17;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.piotrwittig.planPm.RunnerTests;
@@ -658,7 +662,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = UYTX3DLBWN;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -687,7 +691,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = UYTX3DLBWN;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<string>17</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/frontend/ios/fastlane/Appfile
+++ b/frontend/ios/fastlane/Appfile
@@ -1,0 +1,8 @@
+app_identifier("com.piotrwittig.planpm") # The bundle identifier of your app
+apple_id("kacper.marciszewski222@gmail.com") # Your Apple Developer Portal username
+
+itc_team_id("128137845") # App Store Connect Team ID
+team_id("UYTX3DLBWN") # Developer Portal Team ID
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -1,0 +1,30 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    api_key = app_store_connect_api_key(
+      key_id: "Z255Y5V6G6",
+      issuer_id: "47310c6d-17f5-4320-b46c-d996c1093361",
+      key_filepath: "~/.appstoreconnect/private_keys/AuthKey_Z255Y5V6G6.p8",
+    )
+
+    # Read version + build number from pubspec.yaml
+    pubspec = YAML.load_file("../../pubspec.yaml")
+    version_full = pubspec["version"]              # e.g. "1.0.7+17"
+    version_name = version_full.split("+").first   # "1.0.7"
+    build_number = version_full.split("+").last    # "17"
+
+    increment_version_number(
+      version_number: version_name,
+      xcodeproj: "Runner.xcodeproj",
+    )
+    increment_build_number(
+      build_number: build_number,
+      xcodeproj: "Runner.xcodeproj",
+    )
+
+    build_app(workspace: "Runner.xcworkspace", scheme: "Runner")
+    upload_to_testflight(api_key: api_key)
+  end
+end

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -4,9 +4,9 @@ platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :beta do
     api_key = app_store_connect_api_key(
-      key_id: "Z255Y5V6G6",
-      issuer_id: "47310c6d-17f5-4320-b46c-d996c1093361",
-      key_filepath: "~/.appstoreconnect/private_keys/AuthKey_Z255Y5V6G6.p8",
+      key_id: ENV["APP_STORE_KEY_ID"],
+      issuer_id: ENV["APP_STORE_ISSUER_ID"],
+      key_filepath: "~/.appstoreconnect/private_keys/AuthKey_#{ENV["APP_STORE_KEY_ID"]}.p8",
     )
 
     # Read version + build number from pubspec.yaml

--- a/frontend/lib/env_config.dart
+++ b/frontend/lib/env_config.dart
@@ -1,2 +1,5 @@
 // Managed by scripts/switch_env.py — do not edit manually
 const bool kUseTestDb = false;
+
+// Set to true to simulate Supabase errors (all requests will fail)
+const bool kSimulateNetworkErrors = false;

--- a/frontend/lib/global/notifiers.dart
+++ b/frontend/lib/global/notifiers.dart
@@ -1,5 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+final newsCacheManager = CacheManager(
+  Config(
+    'news_images',
+    stalePeriod: const Duration(days: 30),
+    maxNrOfCacheObjects: 50,
+  ),
+);
 
 class ThemeNotifier extends ValueNotifier<ThemeMode> {
   static const String _key = 'theme_mode';

--- a/frontend/lib/global/notifiers.dart
+++ b/frontend/lib/global/notifiers.dart
@@ -1,12 +1,39 @@
+import 'package:file/file.dart' hide FileSystem;
+import 'package:file/local.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+// Stores cached images in Application Support instead of tmp/,
+// so iOS does not evict them under memory pressure.
+class _PersistentFileSystem implements FileSystem {
+  static const _key = 'news_images';
+  static const _localFs = LocalFileSystem();
+  late final Future<Directory> _dir = _initDir();
+
+  static Future<Directory> _initDir() async {
+    final base = await getApplicationSupportDirectory();
+    final dir = _localFs.directory(p.join(base.path, _key));
+    await dir.create(recursive: true);
+    return dir;
+  }
+
+  @override
+  Future<File> createFile(String name) async {
+    final dir = await _dir;
+    if (!(await dir.exists())) await _initDir();
+    return dir.childFile(name);
+  }
+}
 
 final newsCacheManager = CacheManager(
   Config(
     'news_images',
     stalePeriod: const Duration(days: 30),
     maxNrOfCacheObjects: 50,
+    fileSystem: _PersistentFileSystem(),
   ),
 );
 

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -109,6 +109,7 @@
   "noSpecialisationOption": "No specialisation",
   "noSpecialisationForField": "No specialisation available for this field",
   "unexpectedError": "Oops! Something went wrong.",
+  "networkErrorDescription": "Check your internet connection and try again.",
   "pePageTitle": "PE Enrollment",
   "pePageDescription": "Choose your physical education classes for this semester. Remember that enrollment happens periodically.",
   "pePageButton": "Go to enrollment",

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -802,6 +802,12 @@ abstract class AppLocalizations {
   /// **'Ojej! Coś poszło nie tak.'**
   String get unexpectedError;
 
+  /// Opis wyświetlany gdy żądanie sieciowe zawiedzie.
+  ///
+  /// In pl, this message translates to:
+  /// **'Sprawdź połączenie z internetem i spróbuj ponownie.'**
+  String get networkErrorDescription;
+
   /// settings_page.dart - Header for the appearance/theme section.
   ///
   /// In pl, this message translates to:

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -406,6 +406,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unexpectedError => 'Oops! Something went wrong.';
 
   @override
+  String get networkErrorDescription =>
+      'Check your internet connection and try again.';
+
+  @override
   String get appearanceHeader => 'Appearance';
 
   @override

--- a/frontend/lib/l10n/app_localizations_pl.dart
+++ b/frontend/lib/l10n/app_localizations_pl.dart
@@ -403,6 +403,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unexpectedError => 'Ojej! Coś poszło nie tak.';
 
   @override
+  String get networkErrorDescription =>
+      'Sprawdź połączenie z internetem i spróbuj ponownie.';
+
+  @override
   String get appearanceHeader => 'Wygląd';
 
   @override

--- a/frontend/lib/l10n/app_localizations_uk.dart
+++ b/frontend/lib/l10n/app_localizations_uk.dart
@@ -413,6 +413,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get unexpectedError => 'Упс! Щось пішло не так.';
 
   @override
+  String get networkErrorDescription =>
+      'Перевірте з\'єднання з інтернетом і спробуйте ще раз.';
+
+  @override
   String get appearanceHeader => 'Зовнішній вигляд';
 
   @override

--- a/frontend/lib/l10n/app_pl.arb
+++ b/frontend/lib/l10n/app_pl.arb
@@ -463,6 +463,10 @@
   "@unexpectedError": {
     "description": "Ogólny komunikat wyświetlany, gdy w kodzie wystąpi wyjątek."
   },
+  "networkErrorDescription": "Sprawdź połączenie z internetem i spróbuj ponownie.",
+  "@networkErrorDescription": {
+    "description": "Opis wyświetlany gdy żądanie sieciowe zawiedzie."
+  },
   "appearanceHeader": "Wygląd",
   "@appearanceHeader": {
     "description": "settings_page.dart - Header for the appearance/theme section."

--- a/frontend/lib/l10n/app_uk.arb
+++ b/frontend/lib/l10n/app_uk.arb
@@ -128,6 +128,7 @@
   "degreeLevelEngineering": "Інженерний",
   "degreeLevelMasters": "Магістерський",
   "unexpectedError": "Упс! Щось пішло не так.",
+  "networkErrorDescription": "Перевірте з'єднання з інтернетом і спробуйте ще раз.",
   "appearanceHeader": "Зовнішній вигляд",
   "themeLight": "Світла",
   "themeDark": "Темна",

--- a/frontend/lib/pages/home/widgets/news_card.dart
+++ b/frontend/lib/pages/home/widgets/news_card.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/global/notifiers.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 import 'package:plan_pm/pages/news/full_news_page.dart';
 import 'package:flutter_html/flutter_html.dart';
@@ -57,6 +58,7 @@ class NewsCard extends StatelessWidget {
             if (imageUrl != null)
               CachedNetworkImage(
                 imageUrl: imageUrl!,
+                cacheManager: newsCacheManager,
                 imageBuilder: (context, imageProvider) => Ink.image(
                   image: imageProvider,
                   fit: BoxFit.cover,
@@ -65,7 +67,6 @@ class NewsCard extends StatelessWidget {
                 ),
                 placeholder: (context, url) =>
                     Skeleton.leaf(child: SizedBox(height: 150)),
-                // Container(),
                 errorWidget: (context, url, error) => const SizedBox.shrink(),
               ),
             Padding(

--- a/frontend/lib/pages/news/full_news_page.dart
+++ b/frontend/lib/pages/news/full_news_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/global/notifiers.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 
 class FullNewsPage extends StatelessWidget {
@@ -68,6 +69,7 @@ class FullNewsPage extends StatelessWidget {
                     width: double.infinity,
                     height: 300,
                     imageUrl: imageUrl!,
+                    cacheManager: newsCacheManager,
                     placeholder: (context, url) =>
                         const CircularProgressIndicator(),
                     errorWidget: (context, url, error) =>

--- a/frontend/lib/pages/news/full_news_page.dart
+++ b/frontend/lib/pages/news/full_news_page.dart
@@ -72,8 +72,7 @@ class FullNewsPage extends StatelessWidget {
                     cacheManager: newsCacheManager,
                     placeholder: (context, url) =>
                         const CircularProgressIndicator(),
-                    errorWidget: (context, url, error) =>
-                        const Icon(LucideIcons.eggFried),
+                    errorWidget: (context, url, error) => const SizedBox.shrink(),
                   ),
 
                 Padding(

--- a/frontend/lib/pages/welcome/group_selection_page.dart
+++ b/frontend/lib/pages/welcome/group_selection_page.dart
@@ -197,8 +197,8 @@ class GroupSelectionPage extends StatelessWidget {
                   if (snapshot.hasError) {
                     return GenericNoResource(
                       label: l10n.unexpectedError,
-                      icon: LucideIcons.bug,
-                      description: snapshot.error.toString(),
+                      icon: LucideIcons.wifiOff,
+                      description: l10n.networkErrorDescription,
                     );
                   }
                   if (snapshot.data == null) {

--- a/frontend/lib/pages/welcome/input_page.dart
+++ b/frontend/lib/pages/welcome/input_page.dart
@@ -246,8 +246,8 @@ class _InputPageState extends State<InputPage> {
                     if (snapshot.hasError) {
                       return GenericNoResource(
                         label: l10n.unexpectedError,
-                        icon: LucideIcons.bug,
-                        description: snapshot.error.toString(),
+                        icon: LucideIcons.wifiOff,
+                        description: l10n.networkErrorDescription,
                       );
                     }
                     if (snapshot.connectionState != ConnectionState.done) {

--- a/frontend/lib/service/backend_service.dart
+++ b/frontend/lib/service/backend_service.dart
@@ -110,10 +110,7 @@ class BackendService {
         final id = json["id"] as String;
         final url = Supabase.instance.client.storage
             .from("Files")
-            .getPublicUrl(
-              "News/$id.png",
-              transform: const TransformOptions(width: 800),
-            );
+            .getPublicUrl("News/$id.png");
 
         return NewsModel(
           id: json["id"] as String,

--- a/frontend/lib/service/backend_service.dart
+++ b/frontend/lib/service/backend_service.dart
@@ -110,7 +110,10 @@ class BackendService {
         final id = json["id"] as String;
         final url = Supabase.instance.client.storage
             .from("Files")
-            .getPublicUrl("News/$id.png");
+            .getPublicUrl(
+              "News/$id.png",
+              transform: const TransformOptions(width: 800),
+            );
 
         return NewsModel(
           id: json["id"] as String,

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -54,7 +54,9 @@ dependencies:
   sqflite: ^2.4.2
   path: ^1.9.1
   cached_network_image: ^3.4.1
+  file: ^7.0.0
   flutter_cache_manager: ^3.4.1
+  path_provider: ^2.1.5
   smooth_page_indicator: ^1.2.1
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.0

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   sqflite: ^2.4.2
   path: ^1.9.1
   cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
   smooth_page_indicator: ^1.2.1
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.0


### PR DESCRIPTION
## Summary

- **Fastlane (Android)** — `deploy` lane builds a signed AAB via `flutter build appbundle` and uploads it to Google Play production. Separate `promote` lane promotes an internal build to production. Gemfile and Appfile included. FASTLANE.md quick-reference added.
- **Fastlane (iOS)** — `beta` lane reads version and build number directly from `pubspec.yaml`, builds IPA via Xcode, and uploads to TestFlight using App Store Connect API key (no app-specific password needed). Credentials loaded from environment variables.
- **Deploy key excluded from git** — `android/planpm_deploy_key.json`, `Runner.ipa`, and `Runner.app.dSYM.zip` added to `.gitignore`.
- **News image caching fix** — `CachedNetworkImage` was using Flutter's default cache stored in iOS `tmp/`, which the OS evicts under memory pressure, causing repeated re-downloads. A persistent `newsCacheManager` (30-day TTL, max 50 objects) is now shared across `NewsCard` and `FullNewsPage`.
- **Removed Supabase image transformation** — `TransformOptions(width: 800)` requires a Pro plan and was causing 402 errors on the free tier. Removed in favour of uploading pre-compressed images directly to Storage.
- **Silent image error handling** — when an image fails to load (e.g. 402, no network), the image section is silently hidden (`SizedBox.shrink()`) instead of showing a broken placeholder. Cached images are always served from the persistent cache.
- **Graceful network error UI** — `InputPage` and `GroupSelectionPage` now show a friendly "Check your internet connection" message instead of a raw exception stacktrace when Supabase requests fail.
- **Network error simulation flag** — `kSimulateNetworkErrors` added to `env_config.dart` to force all Supabase requests to fail locally for testing purposes.
- **Backend README** — documented `--workers` and `--old-scrapper` flags, `uploadparsetodb.py`, and the `.env_mode` test/prod switching mechanism.