### PR TITLE
feat: announcement modal system

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Get production version
         id: main
         run: |
-          VERSION=$(git show origin/production:frontend/pubspec.yaml | grep '^version:' | awk '{print $2}')
+          git fetch origin ${{ github.base_ref }}
+          VERSION=$(git show origin/${{ github.base_ref }}:frontend/pubspec.yaml | grep '^version:' | awk '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Compare versions
@@ -37,7 +38,7 @@ jobs:
           fi
           LOWEST=$(printf '%s\n%s\n' "$MAIN" "$PR" | sort -V | head -n1)
           if [ "$LOWEST" != "$MAIN" ]; then
-            echo "❌ Version must be greater than the current main version. Found $MAIN → $PR"
+            echo "❌ Version must be greater than the current production version. Found $MAIN → $PR"
             exit 1
           fi
           echo "✅ Version bumped: $MAIN → $PR"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -35,4 +35,9 @@ jobs:
             echo "❌ Version not bumped. Update version in frontend/pubspec.yaml before merging."
             exit 1
           fi
+          LOWEST=$(printf '%s\n%s\n' "$MAIN" "$PR" | sort -V | head -n1)
+          if [ "$LOWEST" != "$MAIN" ]; then
+            echo "❌ Version must be greater than the current main version. Found $MAIN → $PR"
+            exit 1
+          fi
           echo "✅ Version bumped: $MAIN → $PR"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,38 @@
+name: Version bump check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  version-check:
+    name: Verify pubspec.yaml version is bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR version
+        id: pr
+        run: |
+          VERSION=$(grep '^version:' frontend/pubspec.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get main version
+        id: main
+        run: |
+          VERSION=$(git show origin/main:frontend/pubspec.yaml | grep '^version:' | awk '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        run: |
+          PR="${{ steps.pr.outputs.version }}"
+          MAIN="${{ steps.main.outputs.version }}"
+          echo "main: $MAIN"
+          echo "PR:   $PR"
+          if [ "$PR" = "$MAIN" ]; then
+            echo "❌ Version not bumped. Update version in frontend/pubspec.yaml before merging."
+            exit 1
+          fi
+          echo "✅ Version bumped: $MAIN → $PR"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,7 +2,7 @@ name: Version bump check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [production]
 
 jobs:
   version-check:
@@ -19,10 +19,10 @@ jobs:
           VERSION=$(grep '^version:' frontend/pubspec.yaml | awk '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get main version
+      - name: Get production version
         id: main
         run: |
-          VERSION=$(git show origin/main:frontend/pubspec.yaml | grep '^version:' | awk '{print $2}')
+          VERSION=$(git show origin/production:frontend/pubspec.yaml | grep '^version:' | awk '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Compare versions

--- a/frontend/android/fastlane/Appfile
+++ b/frontend/android/fastlane/Appfile
@@ -1,2 +1,2 @@
-json_key_file("/Users/piotrwittig/Coding/plan_pm/frontend/android/planpm_deploy_key.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+json_key_file(ENV["SUPPLY_JSON_KEY"] || File.expand_path("../planpm_deploy_key.json", __dir__)) # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
 package_name("com.piotrwittig.plan_pm") # e.g. com.krausefx.app

--- a/frontend/android/fastlane/FASTLANE.md
+++ b/frontend/android/fastlane/FASTLANE.md
@@ -22,9 +22,8 @@ package_name("com.piotrwittig.plan_pm")
 
 | Lane | Komenda | Co robi |
 |---|---|---|
-| `test` | `fastlane test` | Uruchamia testy Gradle |
-| `beta` | `fastlane beta` | Buduje release APK + wysyła do Crashlytics |
-| `deploy` | `fastlane deploy` | Buduje release APK + wysyła do Google Play |
+| `deploy` | `fastlane deploy` | Buduje release AAB + wysyła do Google Play |
+| `promote` | `fastlane promote` | Promuje istniejące wydanie między trackami w Google Play |
 
 ## Typowy flow wdrożenia
 

--- a/frontend/docs/app.md
+++ b/frontend/docs/app.md
@@ -1,0 +1,120 @@
+# Plan PM – Frontend
+
+Flutter app for students of the Maritime University of Szczecin. Displays class schedules, news, and quick links to university services.
+
+---
+
+## Architecture
+
+```
+Supabase (remote) → BackendService → CacheService → SQLite (local)
+                                                         ↓
+                                                      Pages / Widgets
+```
+
+**State management:** `ValueNotifier` + `SharedPreferences` (no Bloc/Redux).  
+**Persistence:** SQLite via `sqflite` for lectures and news; `SharedPreferences` for settings.  
+**Offline support:** Data is fetched on launch/pull-to-refresh and stored locally. App works offline from cache.
+
+---
+
+## Navigation
+
+### Entry point logic (`main.dart`)
+- First launch → `WelcomePage` → `InputPage` → `GroupSelectionPage` → `MyHomePage`
+- Returning user → `MyHomePage` directly
+
+### Bottom navigation (3 tabs)
+| Tab | Page | Description |
+|-----|------|-------------|
+| Home | `HomePage` | Latest news + today's lectures |
+| Lectures | `LecturesPage` | Full schedule with day selector |
+| News | `NewsPage` | Full news list |
+
+### Sidebar drawer
+| Item | Destination |
+|------|-------------|
+| PE Enrollment | `PePage` (external URL) |
+| Student ID | `StudentIdPage` (external URL) |
+| Virtual University | `VirtualUniversityPage` (external URL) |
+| Settings | `SettingsPage` |
+
+---
+
+## Pages
+
+### Onboarding
+
+| File | Description |
+|------|-------------|
+| `pages/welcome/welcome_page.dart` | 4-slide carousel with Lottie animations introducing the app |
+| `pages/welcome/input_page.dart` | Selects faculty, field of study, year, degree level, study mode. Fetches university structure from Supabase |
+| `pages/welcome/group_selection_page.dart` | Selects class groups after study settings are saved |
+
+### Main
+
+| File | Description |
+|------|-------------|
+| `pages/home/home_page.dart` | Dashboard — latest news (limit 1) + `TodayLectures` widget. Pull-to-refresh |
+| `pages/lectures/lectures_page.dart` | Calendar view with `DaySelection` + skeleton loading. Handles stationary/extramural initial dates |
+| `pages/news/news_page.dart` | Full news list via `NewsBuilder` |
+| `pages/news/full_news_page.dart` | News detail — cached image, HTML content, type badge, timestamp |
+
+### Settings
+
+| File | Description |
+|------|-------------|
+| `pages/settings/settings_page.dart` | Hub — student info summary, links to sub-pages. Debug section (unlocked by 7 taps on version in About) |
+| `pages/settings/appearance_page.dart` | Theme (Light/Dark/System), AMOLED mode, accent color (6 options), event color style (4 options) |
+| `pages/settings/language_page.dart` | Language: Polish, English, Ukrainian, System |
+| `pages/settings/about_page.dart` | App version, KNI info, GitHub link. Easter egg: 7 taps → debug mode |
+| `pages/settings/pe_page.dart` | Opens PE enrollment URL in WebView |
+| `pages/settings/student_id_page.dart` | Opens student ID system URL in WebView |
+| `pages/settings/virtual_university_page.dart` | Opens virtual university URL in WebView |
+| `pages/feedback/feedback_page.dart` | Opens Google Form in external browser |
+
+---
+
+## Services
+
+| File | Responsibility |
+|------|---------------|
+| `service/backend_service.dart` | Supabase queries: `fetchLectures`, `fetchNews`, `fetchGroups`, `fetchStructure` |
+| `service/cache_service.dart` | Orchestrates fetch → clear → insert cycle for lectures and news |
+| `service/database_service.dart` | SQLite CRUD for `lectures` and `news` tables |
+
+---
+
+## Global
+
+| File | Description |
+|------|-------------|
+| `global/student.dart` | Static class holding current student profile (faculty, course, year, groups, study mode) |
+| `global/colors.dart` | `AppColor` — dynamic color system supporting themes, AMOLED, 6 accent colors |
+| `global/notifiers.dart` | ValueNotifiers for theme, locale, accent color, AMOLED, event style, 7-day mode. Also holds `newsCacheManager` |
+| `global/extensions.dart` | String helpers, `DateTime.next()` for finding next weekday |
+| `global/logger.dart` | Thin wrapper around `logger` package |
+| `global/widgets/navigation_bar.dart` | `CustomNavigationBar` (bottom tabs) + `CustomSidebar` (drawer) |
+| `global/widgets/generic_loading.dart` | Dotted-border loading placeholder with label |
+| `global/widgets/generic_no_resource.dart` | Empty / error state with icon, label, description |
+
+---
+
+## Localization
+
+3 languages: **Polish** (pl), **English** (en), **Ukrainian** (uk).  
+Source files in `lib/l10n/`. Generated via `flutter gen-l10n`.  
+~145 translatable strings.
+
+---
+
+## Known issues / missing
+
+| # | Location | Issue |
+|---|----------|-------|
+| 1 | `pages/welcome/group_selection_page.dart:205` | `Text("Null")` shown when snapshot data is null — missing proper error state |
+| 2 | `pages/home/widgets/news_builder.dart` | "Brak aktualności" and description hardcoded in Polish, not using l10n |
+| 3 | `main.dart` comment | `// przetlumaczyc date w dayselection` — dates in `DaySelection` not fully localized |
+| 4 | `pages/settings/settings_page.dart` | "Tryb 7-dniowy" label hardcoded in Polish, not using l10n |
+| 5 | `env_config.dart` | `kSimulateNetworkErrors` flag wires into Supabase init but has no effect on local SQLite reads — offline cache still works normally when flag is on |
+| 6 | General | `webview_flutter` is in `pubspec.yaml` and used in PE/StudentId/VirtualUniversity pages for in-app browsing — previously these opened external URLs; the package is wired in but pages may still fall back to `url_launcher` depending on platform error handling |

--- a/frontend/docs/testing-pr45.md
+++ b/frontend/docs/testing-pr45.md
@@ -1,0 +1,41 @@
+# Testing Plan — PR #45
+
+## 1. Announcement modal — basic flow
+
+- [*] Insert a row into `app_announcements` (`active = true`, `type = 'info'`) → launch app → modal appears on home screen
+- [*] Tap "Rozumiem" → close and relaunch → modal does **not** appear again
+- [*] Set `active = false` → launch → no modal
+- [*] Insert a new row (new UUID, `active = true`) → modal appears again
+
+## 2. Announcement modal — `update` type
+
+- [*] Insert row `type = 'update'`, `store_url` filled in → "Aktualizuj" button opens URL **and closes the dialog**
+- [*] Insert row `type = 'update'`, `store_url = null` → button shows "Rozumiem" (not "Aktualizuj") and closes dialog
+- [ * ] "Pomiń" button closes dialog without opening URL
+
+## 3. Announcement debug flags
+
+- [*] `kDebugAnnouncement = true`, `kDebugAnnouncementType = 'warning'` → modal with triangle icon
+- [*] `kDebugAnnouncementType = 'update'` → modal with rocket icon and "Aktualizuj" button
+- [*] `kDebugAnnouncementType = 'info'` → modal with info icon
+
+## 4. What's new dialog
+
+- [*] `kDebugWhatsNew = true` → dialog appears on every launch
+- [*] Long changelog list in `kChangelog` → list is scrollable, title and version scroll together
+- [*] "Super!" button closes the dialog
+- [*] `kDebugWhatsNew = false` → remove `last_whats_new_version` from SharedPreferences (reinstall or clear data) → dialog appears once, not on next launch
+- [*] First launch (no key in prefs) → dialog does **not** appear
+
+## 5. Dialog order
+
+- [*] Both active (`kDebugWhatsNew = true` + active announcement in DB) → "Co nowego" appears first, after tapping "Super!" the announcement appears
+
+## 6. Version in App Store (Info.plist)
+
+- [ ] Build on device (`flutter build ios`) → check app version in iPhone Settings → should match `pubspec.yaml` (`1.0.8`)
+
+## 7. Regression — navigation
+
+- [*] On iOS bottom nav bar works correctly (tab switching, swipe)
+- [*] On Android standard nav bar works without changes

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -330,13 +330,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.7</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/frontend/lib/api/models/announcement_model.dart
+++ b/frontend/lib/api/models/announcement_model.dart
@@ -1,0 +1,24 @@
+class AnnouncementModel {
+  final String id;
+  final String title;
+  final String message;
+  final String type; // 'info' | 'warning' | 'update'
+  final String? storeUrl;
+
+  const AnnouncementModel({
+    required this.id,
+    required this.title,
+    required this.message,
+    required this.type,
+    this.storeUrl,
+  });
+
+  factory AnnouncementModel.fromJson(Map<String, dynamic> json) =>
+      AnnouncementModel(
+        id: json['id'] as String,
+        title: json['title'] as String,
+        message: json['message'] as String,
+        type: json['type'] as String,
+        storeUrl: json['store_url'] as String?,
+      );
+}

--- a/frontend/lib/changelog.dart
+++ b/frontend/lib/changelog.dart
@@ -1,0 +1,10 @@
+/// Version changelog entries shown in the "What's new" dialog.
+/// Key: version string matching pubspec.yaml (without build number).
+/// Add a new entry here with every release that has user-facing changes.
+const Map<String, List<String>> kChangelog = {
+  '1.0.8': [
+    'Nowy system komunikatów — aplikacja może teraz wyświetlać ważne ogłoszenia i informacje serwisowe bezpośrednio przy starcie',
+    'Trwałe cache zdjęć w aktualnościach — obrazy nie znikają po zamknięciu apki',
+    'Poprawki błędów i ulepszenia wydajności',
+  ],
+};

--- a/frontend/lib/env_config.dart
+++ b/frontend/lib/env_config.dart
@@ -3,3 +3,9 @@ const bool kUseTestDb = false;
 
 // Set to true to simulate Supabase errors (all requests will fail)
 const bool kSimulateNetworkErrors = false;
+
+// Set to true to always show the announcement dialog (for UI development)
+const bool kDebugAnnouncement = false;
+
+// Type of announcement to preview: 'info', 'warning', 'update'
+const String kDebugAnnouncementType = 'update';

--- a/frontend/lib/env_config.dart
+++ b/frontend/lib/env_config.dart
@@ -11,4 +11,4 @@ const bool kDebugAnnouncement = false;
 const String kDebugAnnouncementType = 'update';
 
 // Set to true to always show the "What's new" dialog (for UI development)
-const bool kDebugWhatsNew = true;
+const bool kDebugWhatsNew = false;

--- a/frontend/lib/env_config.dart
+++ b/frontend/lib/env_config.dart
@@ -9,3 +9,6 @@ const bool kDebugAnnouncement = false;
 
 // Type of announcement to preview: 'info', 'warning', 'update'
 const String kDebugAnnouncementType = 'update';
+
+// Set to true to always show the "What's new" dialog (for UI development)
+const bool kDebugWhatsNew = true;

--- a/frontend/lib/global/widgets/announcement_dialog.dart
+++ b/frontend/lib/global/widgets/announcement_dialog.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:plan_pm/api/models/announcement_model.dart';
+import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/l10n/app_localizations.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AnnouncementDialog extends StatelessWidget {
+  const AnnouncementDialog({super.key, required this.announcement});
+
+  final AnnouncementModel announcement;
+
+  static const _gradient = LinearGradient(
+    colors: [Color(0xFF8B5CF6), Color(0xFF3B82F6)],
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
+  );
+
+  IconData get _icon => switch (announcement.type) {
+        'warning' => LucideIcons.alertTriangle,
+        'update' => LucideIcons.rocket,
+        _ => LucideIcons.info,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final isUpdate = announcement.type == 'update';
+
+    return Dialog(
+      backgroundColor: AppColor.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+        side: BorderSide(color: AppColor.outline),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                gradient: _gradient,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Icon(_icon, color: Colors.white, size: 36),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              announcement.title,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColor.onSurface,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              announcement.message,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                height: 1.5,
+                color: AppColor.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 28),
+            _GradientButton(
+              gradient: _gradient,
+              label: isUpdate ? l10n.announcementUpdate : l10n.announcementDismiss,
+              onTap: () async {
+                if (isUpdate && announcement.storeUrl != null) {
+                  await launchUrl(
+                    Uri.parse(announcement.storeUrl!),
+                    mode: LaunchMode.externalApplication,
+                  );
+                } else {
+                  Navigator.of(context).pop();
+                }
+              },
+            ),
+            if (isUpdate) ...[
+              const SizedBox(height: 4),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(
+                  l10n.announcementSkip,
+                  style: TextStyle(color: AppColor.onSurfaceVariant),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GradientButton extends StatelessWidget {
+  const _GradientButton({
+    required this.gradient,
+    required this.label,
+    required this.onTap,
+  });
+
+  final LinearGradient gradient;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: gradient,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(14),
+            onTap: onTap,
+            child: Center(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/global/widgets/announcement_dialog.dart
+++ b/frontend/lib/global/widgets/announcement_dialog.dart
@@ -70,16 +70,19 @@ class AnnouncementDialog extends StatelessWidget {
             const SizedBox(height: 28),
             _GradientButton(
               gradient: _gradient,
-              label: isUpdate ? l10n.announcementUpdate : l10n.announcementDismiss,
+              label: (isUpdate && announcement.storeUrl != null)
+                  ? l10n.announcementUpdate
+                  : l10n.announcementDismiss,
               onTap: () async {
                 if (isUpdate && announcement.storeUrl != null) {
-                  await launchUrl(
-                    Uri.parse(announcement.storeUrl!),
-                    mode: LaunchMode.externalApplication,
-                  );
-                } else {
-                  Navigator.of(context).pop();
+                  try {
+                    await launchUrl(
+                      Uri.parse(announcement.storeUrl!),
+                      mode: LaunchMode.externalApplication,
+                    );
+                  } catch (_) {}
                 }
+                if (context.mounted) Navigator.of(context).pop();
               },
             ),
             if (isUpdate) ...[

--- a/frontend/lib/global/widgets/announcement_dialog.dart
+++ b/frontend/lib/global/widgets/announcement_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:plan_pm/api/models/announcement_model.dart';
 import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/global/widgets/gradient_button.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -26,6 +27,7 @@ class AnnouncementDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final isUpdate = announcement.type == 'update';
+    final hasUrl = announcement.storeUrl != null;
 
     return Dialog(
       backgroundColor: AppColor.surface,
@@ -68,13 +70,13 @@ class AnnouncementDialog extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 28),
-            _GradientButton(
+            GradientButton(
               gradient: _gradient,
-              label: (isUpdate && announcement.storeUrl != null)
+              label: (isUpdate && hasUrl)
                   ? l10n.announcementUpdate
                   : l10n.announcementDismiss,
               onTap: () async {
-                if (isUpdate && announcement.storeUrl != null) {
+                if (isUpdate && hasUrl) {
                   try {
                     await launchUrl(
                       Uri.parse(announcement.storeUrl!),
@@ -85,7 +87,7 @@ class AnnouncementDialog extends StatelessWidget {
                 if (context.mounted) Navigator.of(context).pop();
               },
             ),
-            if (isUpdate) ...[
+            if (isUpdate && hasUrl) ...[
               const SizedBox(height: 4),
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
@@ -96,49 +98,6 @@ class AnnouncementDialog extends StatelessWidget {
               ),
             ],
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _GradientButton extends StatelessWidget {
-  const _GradientButton({
-    required this.gradient,
-    required this.label,
-    required this.onTap,
-  });
-
-  final LinearGradient gradient;
-  final String label;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      height: 52,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: gradient,
-          borderRadius: BorderRadius.circular(14),
-        ),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(14),
-            onTap: onTap,
-            child: Center(
-              child: Text(
-                label,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ),
         ),
       ),
     );

--- a/frontend/lib/global/widgets/gradient_button.dart
+++ b/frontend/lib/global/widgets/gradient_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class GradientButton extends StatelessWidget {
+  const GradientButton({
+    super.key,
+    required this.gradient,
+    required this.label,
+    required this.onTap,
+  });
+
+  final LinearGradient gradient;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: gradient,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(14),
+            onTap: onTap,
+            child: Center(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/global/widgets/navigation_bar.dart
+++ b/frontend/lib/global/widgets/navigation_bar.dart
@@ -11,12 +11,14 @@ class CustomSidebar extends StatelessWidget {
     required this.onStudentIdTap,
     required this.onVirtualUniversityTap,
     required this.onSettingsTap,
+    required this.onWhatsNewTap,
   });
 
   final VoidCallback onPeTap;
   final VoidCallback onStudentIdTap;
   final VoidCallback onVirtualUniversityTap;
   final VoidCallback onSettingsTap;
+  final VoidCallback onWhatsNewTap;
 
   @override
   Widget build(BuildContext context) {
@@ -109,7 +111,7 @@ class CustomSidebar extends StatelessWidget {
 
               const Spacer(),
 
-              // ── Divider + Settings ───────────────────────────────────
+              // ── Divider + What's new + Settings ─────────────────────
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: Divider(
@@ -121,6 +123,17 @@ class CustomSidebar extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: _SidebarNavItem(
+                  icon: LucideIcons.sparkles,
+                  label: l10n.whatsNewTitle,
+                  onTap: () {
+                    HapticFeedback.lightImpact();
+                    onWhatsNewTap();
+                  },
+                ),
+              ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: _SidebarNavItem(

--- a/frontend/lib/global/widgets/whats_new_dialog.dart
+++ b/frontend/lib/global/widgets/whats_new_dialog.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/l10n/app_localizations.dart';
+
+class WhatsNewDialog extends StatelessWidget {
+  const WhatsNewDialog({
+    super.key,
+    required this.version,
+    required this.changes,
+  });
+
+  final String version;
+  final List<String> changes;
+
+  static const _gradient = LinearGradient(
+    colors: [Color(0xFF8B5CF6), Color(0xFF3B82F6)],
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Dialog(
+      backgroundColor: AppColor.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+        side: BorderSide(color: AppColor.outline),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                gradient: _gradient,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: const Icon(LucideIcons.sparkles, color: Colors.white, size: 36),
+            ),
+            const SizedBox(height: 20),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 320),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Text(
+                        l10n.whatsNewTitle,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: AppColor.onSurface,
+                        ),
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        'v$version',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: AppColor.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    ...changes.map((change) => _ChangeItem(text: change)),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _GradientButton(
+              gradient: _gradient,
+              label: l10n.whatsNewGotIt,
+              onTap: () => Navigator.of(context).pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChangeItem extends StatelessWidget {
+  const _ChangeItem({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 5),
+            child: Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(
+                gradient: WhatsNewDialog._gradient,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(
+                fontSize: 14,
+                height: 1.5,
+                color: AppColor.onSurface,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GradientButton extends StatelessWidget {
+  const _GradientButton({
+    required this.gradient,
+    required this.label,
+    required this.onTap,
+  });
+
+  final LinearGradient gradient;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: gradient,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(14),
+            onTap: onTap,
+            child: Center(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/global/widgets/whats_new_dialog.dart
+++ b/frontend/lib/global/widgets/whats_new_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:plan_pm/global/colors.dart';
+import 'package:plan_pm/global/widgets/gradient_button.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 
 class WhatsNewDialog extends StatelessWidget {
@@ -78,7 +79,7 @@ class WhatsNewDialog extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 24),
-            _GradientButton(
+            GradientButton(
               gradient: _gradient,
               label: l10n.whatsNewGotIt,
               onTap: () => Navigator.of(context).pop(),
@@ -125,49 +126,6 @@ class _ChangeItem extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _GradientButton extends StatelessWidget {
-  const _GradientButton({
-    required this.gradient,
-    required this.label,
-    required this.onTap,
-  });
-
-  final LinearGradient gradient;
-  final String label;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      height: 52,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: gradient,
-          borderRadius: BorderRadius.circular(14),
-        ),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(14),
-            onTap: onTap,
-            child: Center(
-              child: Text(
-                label,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -162,5 +162,8 @@
   "debugModeUnlocked": "Debug mode unlocked!",
   "debugTapsRemaining": "{count} more taps to unlock debug",
   "infoSection": "Information",
-  "readMore": "Read more"
+  "readMore": "Read more",
+  "announcementDismiss": "Got it",
+  "announcementUpdate": "Update",
+  "announcementSkip": "Skip"
 }

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -165,5 +165,7 @@
   "readMore": "Read more",
   "announcementDismiss": "Got it",
   "announcementUpdate": "Update",
-  "announcementSkip": "Skip"
+  "announcementSkip": "Skip",
+  "whatsNewTitle": "What's new",
+  "whatsNewGotIt": "Got it!"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -808,6 +808,24 @@ abstract class AppLocalizations {
   /// **'Sprawdź połączenie z internetem i spróbuj ponownie.'**
   String get networkErrorDescription;
 
+  /// No description provided for @announcementDismiss.
+  ///
+  /// In pl, this message translates to:
+  /// **'Rozumiem'**
+  String get announcementDismiss;
+
+  /// No description provided for @announcementUpdate.
+  ///
+  /// In pl, this message translates to:
+  /// **'Aktualizuj'**
+  String get announcementUpdate;
+
+  /// No description provided for @announcementSkip.
+  ///
+  /// In pl, this message translates to:
+  /// **'Pomiń'**
+  String get announcementSkip;
+
   /// settings_page.dart - Header for the appearance/theme section.
   ///
   /// In pl, this message translates to:

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -1035,6 +1035,18 @@ abstract class AppLocalizations {
   /// In pl, this message translates to:
   /// **'Czytaj dalej'**
   String get readMore;
+
+  /// No description provided for @whatsNewTitle.
+  ///
+  /// In pl, this message translates to:
+  /// **'Co nowego'**
+  String get whatsNewTitle;
+
+  /// No description provided for @whatsNewGotIt.
+  ///
+  /// In pl, this message translates to:
+  /// **'Super!'**
+  String get whatsNewGotIt;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -525,4 +525,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get readMore => 'Read more';
+
+  @override
+  String get whatsNewTitle => 'What\'s new';
+
+  @override
+  String get whatsNewGotIt => 'Got it!';
 }

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -410,6 +410,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'Check your internet connection and try again.';
 
   @override
+  String get announcementDismiss => 'Got it';
+
+  @override
+  String get announcementUpdate => 'Update';
+
+  @override
+  String get announcementSkip => 'Skip';
+
+  @override
   String get appearanceHeader => 'Appearance';
 
   @override

--- a/frontend/lib/l10n/app_localizations_pl.dart
+++ b/frontend/lib/l10n/app_localizations_pl.dart
@@ -407,6 +407,15 @@ class AppLocalizationsPl extends AppLocalizations {
       'Sprawdź połączenie z internetem i spróbuj ponownie.';
 
   @override
+  String get announcementDismiss => 'Rozumiem';
+
+  @override
+  String get announcementUpdate => 'Aktualizuj';
+
+  @override
+  String get announcementSkip => 'Pomiń';
+
+  @override
   String get appearanceHeader => 'Wygląd';
 
   @override

--- a/frontend/lib/l10n/app_localizations_pl.dart
+++ b/frontend/lib/l10n/app_localizations_pl.dart
@@ -523,4 +523,10 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get readMore => 'Czytaj dalej';
+
+  @override
+  String get whatsNewTitle => 'Co nowego';
+
+  @override
+  String get whatsNewGotIt => 'Super!';
 }

--- a/frontend/lib/l10n/app_localizations_uk.dart
+++ b/frontend/lib/l10n/app_localizations_uk.dart
@@ -417,6 +417,15 @@ class AppLocalizationsUk extends AppLocalizations {
       'Перевірте з\'єднання з інтернетом і спробуйте ще раз.';
 
   @override
+  String get announcementDismiss => 'Зрозуміло';
+
+  @override
+  String get announcementUpdate => 'Оновити';
+
+  @override
+  String get announcementSkip => 'Пропустити';
+
+  @override
   String get appearanceHeader => 'Зовнішній вигляд';
 
   @override

--- a/frontend/lib/l10n/app_localizations_uk.dart
+++ b/frontend/lib/l10n/app_localizations_uk.dart
@@ -533,4 +533,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get readMore => 'Читати далі';
+
+  @override
+  String get whatsNewTitle => 'Що нового';
+
+  @override
+  String get whatsNewGotIt => 'Чудово!';
 }

--- a/frontend/lib/l10n/app_pl.arb
+++ b/frontend/lib/l10n/app_pl.arb
@@ -560,5 +560,7 @@
   "readMore": "Czytaj dalej",
   "@readMore": {
     "description": "news_card.dart - Read more label shown at the bottom of news card preview."
-  }
+  },
+  "whatsNewTitle": "Co nowego",
+  "whatsNewGotIt": "Super!"
 }

--- a/frontend/lib/l10n/app_pl.arb
+++ b/frontend/lib/l10n/app_pl.arb
@@ -467,6 +467,9 @@
   "@networkErrorDescription": {
     "description": "Opis wyświetlany gdy żądanie sieciowe zawiedzie."
   },
+  "announcementDismiss": "Rozumiem",
+  "announcementUpdate": "Aktualizuj",
+  "announcementSkip": "Pomiń",
   "appearanceHeader": "Wygląd",
   "@appearanceHeader": {
     "description": "settings_page.dart - Header for the appearance/theme section."

--- a/frontend/lib/l10n/app_uk.arb
+++ b/frontend/lib/l10n/app_uk.arb
@@ -163,5 +163,8 @@
   "debugModeUnlocked": "Режим налагодження розблоковано!",
   "debugTapsRemaining": "Ще {count} натискань для розблокування",
   "infoSection": "Інформація",
-  "readMore": "Читати далі"
+  "readMore": "Читати далі",
+  "announcementDismiss": "Зрозуміло",
+  "announcementUpdate": "Оновити",
+  "announcementSkip": "Пропустити"
 }

--- a/frontend/lib/l10n/app_uk.arb
+++ b/frontend/lib/l10n/app_uk.arb
@@ -166,5 +166,7 @@
   "readMore": "Читати далі",
   "announcementDismiss": "Зрозуміло",
   "announcementUpdate": "Оновити",
-  "announcementSkip": "Пропустити"
+  "announcementSkip": "Пропустити",
+  "whatsNewTitle": "Що нового",
+  "whatsNewGotIt": "Чудово!"
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -368,6 +368,18 @@ class _MyHomePageState extends State<MyHomePage> {
             MaterialPageRoute(builder: (context) => const SettingsPage()),
           );
         },
+        onWhatsNewTap: () async {
+          Navigator.of(context).pop();
+          final info = await PackageInfo.fromPlatform();
+          final version = info.version;
+          final changes = kChangelog[version] ?? kChangelog.values.last;
+          if (!context.mounted) return;
+          showDialog(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => WhatsNewDialog(version: version, changes: changes),
+          );
+        },
       ),
       bottomNavigationBar: CustomNavigationBar(
         index: _currentIndex,

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -28,7 +28,10 @@ import 'package:plan_pm/global/logger.dart';
 import 'package:plan_pm/api/models/announcement_model.dart';
 
 import 'package:plan_pm/global/widgets/announcement_dialog.dart';
+import 'package:plan_pm/global/widgets/whats_new_dialog.dart';
 import 'package:plan_pm/service/backend_service.dart';
+import 'package:plan_pm/changelog.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 // Funkcja odpowiada za inicjalizację aplikacji na wejściu - robi wszystkie rzeczy, a następnie zdejmuje splashScreen
 Future<Widget> appInitialization() async {
@@ -224,7 +227,46 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkAnnouncement());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _checkWhatsNew();
+      await _checkAnnouncement();
+    });
+  }
+
+  Future<void> _checkWhatsNew() async {
+    final info = await PackageInfo.fromPlatform();
+    final version = info.version;
+    final changes = kChangelog[version] ?? kChangelog.values.last;
+
+    if (kDebugWhatsNew) {
+      if (!mounted) return;
+      await showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => WhatsNewDialog(version: version, changes: changes),
+      );
+      return;
+    }
+
+    if (kChangelog[version] == null) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final lastSeen = prefs.getString('last_whats_new_version');
+
+    if (lastSeen == null) {
+      await prefs.setString('last_whats_new_version', version);
+      return;
+    }
+    if (lastSeen == version) return;
+
+    if (!mounted) return;
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => WhatsNewDialog(version: version, changes: changes),
+    );
+
+    await prefs.setString('last_whats_new_version', version);
   }
 
   Future<void> _checkAnnouncement() async {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -25,6 +25,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:plan_pm/global/logger.dart';
+import 'package:plan_pm/api/models/announcement_model.dart';
+
+import 'package:plan_pm/global/widgets/announcement_dialog.dart';
+import 'package:plan_pm/service/backend_service.dart';
 
 // Funkcja odpowiada za inicjalizację aplikacji na wejściu - robi wszystkie rzeczy, a następnie zdejmuje splashScreen
 Future<Widget> appInitialization() async {
@@ -216,6 +220,51 @@ class _MyHomePageState extends State<MyHomePage> {
   final PreloadPageController _preloadPageController = PreloadPageController(
     initialPage: 0,
   );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkAnnouncement());
+  }
+
+  Future<void> _checkAnnouncement() async {
+    final AnnouncementModel? announcement;
+
+    if (kDebugAnnouncement) {
+      announcement = AnnouncementModel(
+        id: 'debug',
+        title: switch (kDebugAnnouncementType) {
+          'warning' => 'Uwaga!',
+          'update' => 'Dostępna aktualizacja!',
+          _ => 'Komunikat systemowy',
+        },
+        message: switch (kDebugAnnouncementType) {
+          'warning' => 'Trwają prace serwisowe dla kierunku Mechatronika. Przepraszamy za utrudnienia.',
+          'update' => 'Wprowadziliśmy nowe funkcje i poprawiliśmy wydajność. Zaktualizuj aplikację do najnowszej wersji, aby działała jeszcze lepiej.',
+          _ => 'Mamy dla Ciebie ważną informację. Sprawdź szczegóły poniżej.',
+        },
+        type: kDebugAnnouncementType,
+        storeUrl: 'https://example.com',
+      );
+    } else {
+      announcement = await BackendService().fetchAnnouncement();
+      if (announcement == null) return;
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getString('dismissed_announcement') == announcement.id) return;
+    }
+
+    if (!mounted) return;
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => AnnouncementDialog(announcement: announcement!),
+    );
+
+    if (!kDebugAnnouncement) {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('dismissed_announcement', announcement.id);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/lib/pages/news/full_news_page.dart
+++ b/frontend/lib/pages/news/full_news_page.dart
@@ -65,13 +65,22 @@ class FullNewsPage extends StatelessWidget {
               children: [
                 if (imageUrl != null)
                   CachedNetworkImage(
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: 300,
                     imageUrl: imageUrl!,
                     cacheManager: newsCacheManager,
-                    placeholder: (context, url) =>
-                        const CircularProgressIndicator(),
+                    imageBuilder: (context, imageProvider) => SizedBox(
+                      height: 300,
+                      width: double.infinity,
+                      child: Image(
+                        image: imageProvider,
+                        fit: BoxFit.cover,
+                        width: double.infinity,
+                      ),
+                    ),
+                    placeholder: (context, url) => const SizedBox(
+                      height: 300,
+                      width: double.infinity,
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
                     errorWidget: (context, url, error) => const SizedBox.shrink(),
                   ),
 

--- a/frontend/lib/service/backend_service.dart
+++ b/frontend/lib/service/backend_service.dart
@@ -1,5 +1,6 @@
 import 'package:intl/intl.dart';
 // import 'dart:developer' as developer;
+import 'package:plan_pm/api/models/announcement_model.dart';
 import 'package:plan_pm/api/models/lecture_model.dart';
 import 'package:plan_pm/api/models/news_model.dart';
 import 'package:plan_pm/global/student.dart';
@@ -124,6 +125,17 @@ class BackendService {
       return news;
     }
     return [];
+  }
+
+  Future<AnnouncementModel?> fetchAnnouncement() async {
+    final response = await Supabase.instance.client
+        .from('app_announcements')
+        .select()
+        .eq('active', true)
+        .order('created_at', ascending: false)
+        .limit(1);
+    if (response.isEmpty) return null;
+    return AnnouncementModel.fromJson(response.first);
   }
 
   Future<Map<String, Map<String, List<String>>>> fetchStructure() async {

--- a/frontend/lib/service/backend_service.dart
+++ b/frontend/lib/service/backend_service.dart
@@ -129,10 +129,10 @@ class BackendService {
 
   Future<AnnouncementModel?> fetchAnnouncement() async {
     final response = await Supabase.instance.client
-        .from('app_announcements')
+        .from("app_announcements")
         .select()
-        .eq('active', true)
-        .order('created_at', ascending: false)
+        .eq("active", true)
+        .order("created_at", ascending: false)
         .limit(1);
     if (response.isEmpty) return null;
     return AnnouncementModel.fromJson(response.first);

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.7+17
+version: 1.0.8+18
 
 environment:
   sdk: ^3.8.0

--- a/scripts/switch_env.py
+++ b/scripts/switch_env.py
@@ -17,6 +17,9 @@ ENV_MODE_FILE.write_text(f"{mode}\n")
 ENV_CONFIG_DART.write_text(
     "// Managed by scripts/switch_env.py — do not edit manually\n"
     f"const bool kUseTestDb = {str(mode == 'test').lower()};\n"
+    "\n"
+    "// Set to true to simulate Supabase errors (all requests will fail)\n"
+    "const bool kSimulateNetworkErrors = false;\n"
 )
 
 print(f"Przestawiono na: {mode}")

--- a/scripts/switch_env.py
+++ b/scripts/switch_env.py
@@ -26,6 +26,9 @@ ENV_CONFIG_DART.write_text(
     "\n"
     "// Type of announcement to preview: 'info', 'warning', 'update'\n"
     "const String kDebugAnnouncementType = 'update';\n"
+    "\n"
+    "// Set to true to always show the \"What's new\" dialog (for UI development)\n"
+    "const bool kDebugWhatsNew = false;\n"
 )
 
 print(f"Przestawiono na: {mode}")

--- a/scripts/switch_env.py
+++ b/scripts/switch_env.py
@@ -20,6 +20,12 @@ ENV_CONFIG_DART.write_text(
     "\n"
     "// Set to true to simulate Supabase errors (all requests will fail)\n"
     "const bool kSimulateNetworkErrors = false;\n"
+    "\n"
+    "// Set to true to always show the announcement dialog (for UI development)\n"
+    "const bool kDebugAnnouncement = false;\n"
+    "\n"
+    "// Type of announcement to preview: 'info', 'warning', 'update'\n"
+    "const String kDebugAnnouncementType = 'update';\n"
 )
 
 print(f"Przestawiono na: {mode}")


### PR DESCRIPTION
## Summary

- Adds an in-app announcement system backed by the `app_announcements` Supabase table — on app start, the latest active announcement is fetched and shown as a modal if the user hasn't dismissed it yet (tracked via SharedPreferences)
- Modal supports three types: `info`, `warning`, `update` — the `update` type shows an App Store redirect button and a skip option
- New debug flags in `env_config.dart` (`kDebugAnnouncement`, `kDebugAnnouncementType`) allow previewing the modal locally without hitting the database
- `switch_env.py` updated to preserve debug flags when switching environments
- GitHub Actions workflow that blocks merging to `main` if the version in `pubspec.yaml` is not bumped

## Supabase — required migration

Run manually in both databases (prod and test):

```sql
create table app_announcements (
  id          uuid primary key default gen_random_uuid(),
  created_at  timestamptz default now(),
  title       text not null,
  message     text not null,
  type        text not null check (type in ('info', 'warning', 'update')),
  active      boolean not null default true,
  store_url   text
);

alter table app_announcements enable row level security;
grant select on app_announcements to anon, authenticated;
```

## Test plan

- [x] Insert a row into `app_announcements` with `active = true`, `type = 'info'` → modal appears on app start at the home screen
- [x] Tap "Got it" → close and relaunch → modal does not appear again
- [x] Set `active = false` → no modal shown
- [x] Insert a new row (new UUID) → modal appears again
- [x] Test `update` type: `type = 'update'`, `store_url` filled in → "Update" button opens the URL, "Skip" closes the modal
- [x] Set `kDebugAnnouncement = true` in `env_config.dart` → modal appears without any database entry
- [x] Run `switch_env.py prod` and `switch_env.py test` → debug flags are not reset