### PR TITLE
chore: remove unused dependencies and upgrade packages

### DIFF
--- a/frontend/lib/service/database_service.dart
+++ b/frontend/lib/service/database_service.dart
@@ -94,7 +94,7 @@ class DatabaseService {
   }) async {
     final db = await database;
     final Map<String, dynamic> values = {
-      if (id != null) _lecturesIdColumnName: id,
+      _lecturesIdColumnName: ?id,
       _lecturesNameColumnName: name,
       _lecturesStartTimeColumnName: startTime,
       _lecturesEndTimeColumnName: endTime,
@@ -157,7 +157,7 @@ class DatabaseService {
   }) async {
     final db = await database;
     final Map<String, dynamic> values = {
-      if (id != null) _newsIdColumnName: id,
+      _newsIdColumnName: ?id,
       _newsTitleColumnName: title,
       _newsCreatedAtColumnName: createdAt.toUtc().millisecondsSinceEpoch,
       _newsImageUrlColumnName: imageUrl,

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
   lottie: ^3.3.1
   lucide_icons: ^0.257.0
   supabase_flutter: ^2.10.3
@@ -44,7 +43,6 @@ dependencies:
   dotted_border: ^3.1.0
   collection: ^1.19.1
   flutter_native_splash: ^2.4.7
-  webview_flutter: ^4.13.0
   flutter_html: ^3.0.0
 
   # Provides localizations and translations for Flutter's built-in widgets.
@@ -57,7 +55,6 @@ dependencies:
   file: ^7.0.0
   flutter_cache_manager: ^3.4.1
   path_provider: ^2.1.5
-  smooth_page_indicator: ^1.2.1
   url_launcher: ^6.3.2
   package_info_plus: ^9.0.0
   logger: ^2.6.2
@@ -72,7 +69,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary

- Remove unused packages: `cupertino_icons`, `webview_flutter`, `smooth_page_indicator`
- Upgrade `supabase_flutter` 2.10 → 2.12, `shared_preferences`, `skeletonizer`, `logger`, `lottie` and 30+ transitive deps
- Upgrade `flutter_lints` to v6
- Use null-aware map entries (`?id`) in `DatabaseService`

## Test plan

- [ ] `flutter analyze` passes (no issues)
- [ ] App builds and runs on iOS/Android