### PR TITLE
ci: deployment pipeline — Fastlane iOS/Android, branch guards, env checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+name: Deploy to App Store & Play Store
+
+on:
+  push:
+    branches: [deployment]
+
+jobs:
+  ios:
+    name: iOS → TestFlight
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Flutter dependencies
+        working-directory: frontend
+        run: flutter pub get
+
+      - name: Decode certificate
+        working-directory: frontend/ios
+        run: |
+          echo "${{ secrets.IOS_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
+
+      - name: Decode provisioning profile
+        working-directory: frontend/ios
+        run: |
+          echo "${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}" | base64 --decode > profile.mobileprovision
+
+      - name: Install Ruby dependencies
+        working-directory: frontend/ios
+        run: bundle install
+
+      - name: Run Fastlane beta
+        working-directory: frontend/ios
+        env:
+          APP_STORE_KEY_ID: ${{ secrets.APP_STORE_KEY_ID }}
+          APP_STORE_ISSUER_ID: ${{ secrets.APP_STORE_ISSUER_ID }}
+          APP_STORE_PRIVATE_KEY: ${{ secrets.APP_STORE_PRIVATE_KEY }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          CI: true
+        run: bundle exec fastlane ios beta
+
+  android:
+    name: Android → Play Store
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Flutter dependencies
+        working-directory: frontend
+        run: flutter pub get
+
+      - name: Decode keystore
+        working-directory: frontend/android
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > upload-keystore.jks
+
+      - name: Install Ruby dependencies
+        working-directory: frontend/android
+        run: bundle install
+
+      - name: Run Fastlane deploy
+        working-directory: frontend/android
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
+        run: bundle exec fastlane android deploy

--- a/.github/workflows/deployment-env-check.yml
+++ b/.github/workflows/deployment-env-check.yml
@@ -1,0 +1,35 @@
+name: Deployment env check
+
+on:
+  pull_request:
+    branches: [deployment]
+
+jobs:
+  deployment-env-check:
+    name: deployment-env-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check no debug flags are enabled
+        run: |
+          FILE="frontend/lib/env_config.dart"
+          FAILED=0
+
+          check() {
+            local KEY=$1
+            local VAL=$(grep "^const bool $KEY" "$FILE" | grep -o 'true\|false')
+            if [ "$VAL" = "true" ]; then
+              echo "❌ $KEY is set to true — must be false before deploying"
+              FAILED=1
+            else
+              echo "✅ $KEY = false"
+            fi
+          }
+
+          check kUseTestDb
+          check kSimulateNetworkErrors
+          check kDebugAnnouncement
+          check kDebugWhatsNew
+
+          [ $FAILED -eq 0 ] || exit 1

--- a/.github/workflows/deployment-source-check.yml
+++ b/.github/workflows/deployment-source-check.yml
@@ -1,0 +1,19 @@
+name: Source branch check
+
+on:
+  pull_request:
+    branches: [deployment]
+
+jobs:
+  source-branch-check:
+    name: source-branch-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR comes from main
+        run: |
+          if [ "${{ github.head_ref }}" != "main" ]; then
+            echo "❌ PRs to 'deployment' are only allowed from 'main'."
+            echo "   This PR comes from: '${{ github.head_ref }}'"
+            exit 1
+          fi
+          echo "✅ Source branch is 'main'"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,7 +2,7 @@ name: Version bump check
 
 on:
   pull_request:
-    branches: [production]
+    branches: [production, deployment]
 
 jobs:
   version-check:

--- a/frontend/android/fastlane/Fastfile
+++ b/frontend/android/fastlane/Fastfile
@@ -3,12 +3,21 @@ default_platform(:android)
 platform :android do
   desc "Deploy a new version to the Google Play"
   lane :deploy do
-    # Build signed AAB via Flutter (from the frontend root)
+    # Write key.properties from env vars for release signing
+    key_props = [
+      "storePassword=#{ENV["ANDROID_KEYSTORE_PASSWORD"]}",
+      "keyPassword=#{ENV["ANDROID_KEY_PASSWORD"]}",
+      "keyAlias=#{ENV["ANDROID_KEY_ALIAS"]}",
+      "storeFile=../upload-keystore.jks",
+    ].join("\n")
+    File.write("../../android/key.properties", key_props)
+
     sh("cd ../../ && flutter build appbundle --release")
 
     upload_to_play_store(
       track: "production",
       aab: "../build/app/outputs/bundle/release/app-release.aab",
+      json_key_data: ENV["PLAY_STORE_JSON_KEY"],
       skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,
@@ -21,6 +30,7 @@ platform :android do
     upload_to_play_store(
       track: "internal",
       track_promote_to: "production",
+      json_key_data: ENV["PLAY_STORE_JSON_KEY"],
       skip_upload_apk: true,
       skip_upload_aab: true,
       skip_upload_metadata: true,

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -6,14 +6,44 @@ platform :ios do
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_KEY_ID"],
       issuer_id: ENV["APP_STORE_ISSUER_ID"],
-      key_filepath: "~/.appstoreconnect/private_keys/AuthKey_#{ENV["APP_STORE_KEY_ID"]}.p8",
+      key_content: ENV["APP_STORE_PRIVATE_KEY"],
     )
+
+    # Install certificate and provisioning profile in CI
+    if ENV["CI"]
+      keychain_name = "ci_keychain"
+      keychain_password = "ci_temp"
+
+      create_keychain(
+        name: keychain_name,
+        password: keychain_password,
+        default_keychain: true,
+        unlock: true,
+        timeout: 3600,
+      )
+
+      import_certificate(
+        certificate_path: "certificate.p12",
+        certificate_password: ENV["IOS_CERTIFICATE_PASSWORD"],
+        keychain_name: keychain_name,
+        keychain_password: keychain_password,
+      )
+
+      install_provisioning_profile(path: "profile.mobileprovision")
+
+      update_code_signing_settings(
+        use_automatic_signing: false,
+        path: "Runner.xcodeproj",
+        code_sign_identity: "Apple Distribution",
+        profile_name: "iOS Team Store Provisioning Profile: com.piotrwittig.planpm",
+      )
+    end
 
     # Read version + build number from pubspec.yaml
     pubspec = YAML.load_file("../../pubspec.yaml")
-    version_full = pubspec["version"]              # e.g. "1.0.7+17"
-    version_name = version_full.split("+").first   # "1.0.7"
-    build_number = version_full.split("+").last    # "17"
+    version_full = pubspec["version"]
+    version_name = version_full.split("+").first
+    build_number = version_full.split("+").last
 
     increment_version_number(
       version_number: version_name,


### PR DESCRIPTION
## Summary

- Add `deploy.yml` — triggers on push to `deployment`, runs Fastlane iOS (TestFlight) and Android (Play Store) jobs
- Add `deployment-source-check.yml` — blocks PRs to `deployment` that don't come from `main`
- Add `deployment-env-check.yml` — blocks PRs to `deployment` if any debug flag is enabled (`kUseTestDb`, `kDebugAnnouncement`, `kDebugWhatsNew`, `kSimulateNetworkErrors`)
- Update `version-check.yml` — now also runs on PRs to `deployment`
- Update iOS `Fastfile` — use `key_content` instead of `key_filepath` for CI compatibility; add certificate/profile install steps when running in CI
- Update Android `Fastfile` — write `key.properties` from env vars; use `json_key_data` instead of file path

## Test plan

- [ ] Merge to `main`, then open PR from `main` → `deployment` and verify all 3 status checks appear
- [ ] Open PR from a non-`main` branch → `deployment` and verify `source-branch-check` fails
- [ ] Set `kUseTestDb = true`, open PR → `deployment` and verify `deployment-env-check` fails
- [ ] Merge a PR to `deployment` and verify both iOS and Android jobs run in Actions