### PR TITLE
fix: install bundler before bundle install on Android CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,9 @@ jobs:
 
       - name: Install Ruby dependencies
         working-directory: frontend/android
-        run: bundle install
+        run: |
+          gem install bundler
+          bundle install
 
       - name: Run Fastlane deploy
         working-directory: frontend/android

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -29,13 +29,13 @@ platform :ios do
         keychain_password: keychain_password,
       )
 
-      install_provisioning_profile(path: "profile.mobileprovision")
+      profile_uuid = install_provisioning_profile(path: "profile.mobileprovision")
 
       update_code_signing_settings(
         use_automatic_signing: false,
         path: "Runner.xcodeproj",
         code_sign_identity: "Apple Distribution",
-        profile_name: "iOS Team Store Provisioning Profile: com.piotrwittig.planpm",
+        profile_uuid: profile_uuid,
       )
     end
 


### PR DESCRIPTION
Fixes `bundle: command not found` on Ubuntu runner — bundler must be installed explicitly before `bundle install`.