### PR TITLE
chore bump release version and refresh readme screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,45 @@
 
 ## Screenshots
 
-<p float="left">
-  <img src="screenshots/1.png" width="22%" />
-  <img src="screenshots/2.png" width="22%" />
-  <img src="screenshots/3.png" width="22%" />
-  <img src="screenshots/4.png" width="22%" />
-</p>
+### iOS
+
+<table>
+  <tr>
+    <td><img src="docs/pr-assets/liquid-glass/ios-01.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-02.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-03.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-04.png" width="220" /></td>
+  </tr>
+  <tr>
+    <td><img src="docs/pr-assets/liquid-glass/ios-05.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-06.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-07.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/ios-08.png" width="220" /></td>
+  </tr>
+</table>
+
+### Android
+
+<table>
+  <tr>
+    <td><img src="docs/pr-assets/liquid-glass/android-01.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-02.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-03.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-04.png" width="220" /></td>
+  </tr>
+  <tr>
+    <td><img src="docs/pr-assets/liquid-glass/android-05.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-06.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-07.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-08.png" width="220" /></td>
+  </tr>
+  <tr>
+    <td><img src="docs/pr-assets/liquid-glass/android-09.png" width="220" /></td>
+    <td><img src="docs/pr-assets/liquid-glass/android-10.png" width="220" /></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
 
 ---
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 1.1.2
+
+### pl-PL
+
+- Nowy iOS-owy wygląd aplikacji z liquid glass navigation barem, przebudowanym sidebarem oraz odświeżonym układem ekranu głównego
+- Spójniejsze paski nawigacyjne i status bar w jasnym oraz ciemnym motywie
+- Przeprojektowane ekrany ustawień, wyglądu, języka oraz informacje o roli i grupie
+- Uspójnione karty aktualności i pełny widok newsa: subtelniejsze obramowania, lepsza czytelność i wyraźniejsze elementy interaktywne
+- Migracja części logiki danych do widoków SQL w Supabase oraz poprawki planu prowadzących i sortowania zajęć
+- Lepsze odświeżanie planu i aktualności dzięki mechanizmowi stale-while-revalidate
+- Aktualizacja backendowych zależności i poprawek bezpieczeństwa dla bibliotek Python
+
+### en-US
+
+- New iOS-style app polish with a liquid glass navigation bar, redesigned sidebar, and refreshed home shell layout
+- More consistent navigation bars and status bar behavior in both light and dark themes
+- Redesigned settings, appearance, language, and role/group info screens
+- Refined news cards and full news view with subtler borders, better readability, and clearer interactive elements
+- Migrated part of the data logic to Supabase SQL views and fixed lecturer schedule handling and lecture sorting
+- Improved schedule and news refresh flow with stale-while-revalidate behavior
+- Updated backend dependencies and security-related Python packages
+
 ## 1.1.1
 
 ### pl-PL

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+21
+version: 1.1.2+22
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## What changed

- bumped the app version from `1.1.1+21` to `1.1.2+22`
- added a new `1.1.2` entry to `frontend/CHANGELOG.md` in both Polish and English
- replaced the old README screenshot block with the current iOS and Android screenshots from `docs/pr-assets/liquid-glass/`
- removed the legacy `screenshots/*.png` references from the README

## Why

- the release branch needed a fresh app version before deployment
- the changelog for the next release should reflect the actual UI, data, and backend dependency changes already merged into `main`
- the README was still showing the old screenshot paths instead of the current documented assets

## Notes

- this PR is intentionally separate from the `main -> deployment` release PR so the metadata/docs cleanup can be reviewed and merged independently first
