### PR TITLE
fix: resolve lecture color shuffle, role switch crash, and nav bar UI issues

### DIFF
--- a/frontend/lib/global/widgets/navigation_bar.dart
+++ b/frontend/lib/global/widgets/navigation_bar.dart
@@ -21,16 +21,17 @@ class CustomNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final isLight = Theme.of(context).brightness == Brightness.light;
 
-    return ClipRect(
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-        child: Container(
-          decoration: BoxDecoration(
-            border: Border(top: BorderSide(color: AppColor.outline)),
-          ),
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: AppColor.outline)),
+      ),
+      child: ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
           child: BottomNavigationBar(
-            backgroundColor: AppColor.background.withValues(alpha: 0.5),
+            backgroundColor: AppColor.background.withValues(alpha: isLight ? 0.92 : 0.5),
             selectedItemColor: AppColor.primary,
             unselectedItemColor: AppColor.onBackgroundVariant,
             currentIndex: index,
@@ -59,3 +60,4 @@ class CustomNavigationBar extends StatelessWidget {
     );
   }
 }
+

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -1027,14 +1027,26 @@ abstract class AppLocalizations {
   /// about_page.dart - Snackbar message shown when debug mode is unlocked after 7 taps.
   ///
   /// In pl, this message translates to:
-  /// **'Tryb debug odblokowany!'**
+  /// **'Jesteś już deweloperem'**
   String get debugModeUnlocked;
 
   /// about_page.dart - Hint shown after 3+ taps on version number, showing remaining taps needed.
   ///
   /// In pl, this message translates to:
-  /// **'Jeszcze {count} tapnięć do odblokowania debug'**
+  /// **'Zostało jeszcze {count} naciśnięć, aby zostać deweloperem'**
   String debugTapsRemaining(int count);
+
+  /// No description provided for @debugModeDisable.
+  ///
+  /// In pl, this message translates to:
+  /// **'Wyłącz tryb dewelopera'**
+  String get debugModeDisable;
+
+  /// No description provided for @debugModeDisabled.
+  ///
+  /// In pl, this message translates to:
+  /// **'Tryb dewelopera wyłączony'**
+  String get debugModeDisabled;
 
   /// No description provided for @infoSection.
   ///
@@ -1137,6 +1149,18 @@ abstract class AppLocalizations {
   /// In pl, this message translates to:
   /// **'Przełącz na plan studenta'**
   String get roleStudentViewSubtitle;
+
+  /// No description provided for @roleViewingAsStudent.
+  ///
+  /// In pl, this message translates to:
+  /// **'Przeglądasz aktualnie plan jako student.'**
+  String get roleViewingAsStudent;
+
+  /// No description provided for @roleViewingAsLecturer.
+  ///
+  /// In pl, this message translates to:
+  /// **'Przeglądasz aktualnie plan jako wykładowca.'**
+  String get roleViewingAsLecturer;
 
   /// No description provided for @roleCurrentlyActive.
   ///

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -519,12 +519,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get debugReturnToWelcome => 'Return to Welcome Screen';
 
   @override
-  String get debugModeUnlocked => 'Debug mode unlocked!';
+  String get debugModeUnlocked => 'You are now a developer';
 
   @override
   String debugTapsRemaining(int count) {
-    return '$count more taps to unlock debug';
+    return '$count more taps to become a developer';
   }
+
+  @override
+  String get debugModeDisable => 'Disable developer mode';
+
+  @override
+  String get debugModeDisabled => 'Developer mode disabled';
 
   @override
   String get infoSection => 'Information';
@@ -581,6 +587,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get roleStudentViewSubtitle => 'Switch to student schedule';
+
+  @override
+  String get roleViewingAsStudent =>
+      'You are currently viewing the schedule as a student.';
+
+  @override
+  String get roleViewingAsLecturer =>
+      'You are currently viewing the schedule as a lecturer.';
 
   @override
   String get roleCurrentlyActive => 'Currently active';

--- a/frontend/lib/l10n/app_localizations_pl.dart
+++ b/frontend/lib/l10n/app_localizations_pl.dart
@@ -517,12 +517,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get debugReturnToWelcome => 'Powrót do Welcome Screen';
 
   @override
-  String get debugModeUnlocked => 'Tryb debug odblokowany!';
+  String get debugModeUnlocked => 'Jesteś już deweloperem';
 
   @override
   String debugTapsRemaining(int count) {
-    return 'Jeszcze $count tapnięć do odblokowania debug';
+    return 'Zostało jeszcze $count naciśnięć, aby zostać deweloperem';
   }
+
+  @override
+  String get debugModeDisable => 'Wyłącz tryb dewelopera';
+
+  @override
+  String get debugModeDisabled => 'Tryb dewelopera wyłączony';
 
   @override
   String get infoSection => 'Informacje';
@@ -580,6 +586,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get roleStudentViewSubtitle => 'Przełącz na plan studenta';
+
+  @override
+  String get roleViewingAsStudent => 'Przeglądasz aktualnie plan jako student.';
+
+  @override
+  String get roleViewingAsLecturer =>
+      'Przeglądasz aktualnie plan jako wykładowca.';
 
   @override
   String get roleCurrentlyActive => 'Aktualnie aktywny';

--- a/frontend/lib/l10n/app_localizations_uk.dart
+++ b/frontend/lib/l10n/app_localizations_uk.dart
@@ -527,12 +527,18 @@ class AppLocalizationsUk extends AppLocalizations {
   String get debugReturnToWelcome => 'Повернутися до Welcome Screen';
 
   @override
-  String get debugModeUnlocked => 'Режим налагодження розблоковано!';
+  String get debugModeUnlocked => 'Ви вже розробник';
 
   @override
   String debugTapsRemaining(int count) {
-    return 'Ще $count натискань для розблокування';
+    return 'Ще $count натискань, щоб стати розробником';
   }
+
+  @override
+  String get debugModeDisable => 'Вимкнути режим розробника';
+
+  @override
+  String get debugModeDisabled => 'Режим розробника вимкнено';
 
   @override
   String get infoSection => 'Інформація';
@@ -590,6 +596,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get roleStudentViewSubtitle => 'Переключитися на розклад студента';
+
+  @override
+  String get roleViewingAsStudent => 'Ви переглядаєте розклад як студент.';
+
+  @override
+  String get roleViewingAsLecturer => 'Ви переглядаєте розклад як викладач.';
 
   @override
   String get roleCurrentlyActive => 'Зараз активний';

--- a/frontend/lib/pages/home/home_page.dart
+++ b/frontend/lib/pages/home/home_page.dart
@@ -31,6 +31,7 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     return RefreshIndicator(
+      edgeOffset: MediaQuery.of(context).padding.top + kToolbarHeight,
       onRefresh: () async {
         AppLogger.d("Refreshing home page elements...");
         final CacheService cacheService = CacheService();

--- a/frontend/lib/pages/home/home_shell.dart
+++ b/frontend/lib/pages/home/home_shell.dart
@@ -189,13 +189,18 @@ class _MyHomePageState extends State<MyHomePage>
               backgroundColor: Colors.transparent,
               forceMaterialTransparency: true,
               shape: Border(bottom: BorderSide(color: AppColor.outline)),
-              flexibleSpace: ClipRect(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-                  child: Container(
-                    color: AppColor.background.withValues(alpha: 0.5),
-                  ),
-                ),
+              flexibleSpace: Builder(
+                builder: (context) {
+                  final isLight = Theme.of(context).brightness == Brightness.light;
+                  return ClipRect(
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                      child: Container(
+                        color: AppColor.background.withValues(alpha: isLight ? 0.92 : 0.5),
+                      ),
+                    ),
+                  );
+                },
               ),
               leading: Builder(
                 builder: (ctx) => defaultTargetPlatform == TargetPlatform.iOS

--- a/frontend/lib/pages/home/utils/lecture_filters.dart
+++ b/frontend/lib/pages/home/utils/lecture_filters.dart
@@ -21,7 +21,11 @@ List<LectureModel> getClosestLectures(
     );
     return !lectureEnd.isBefore(referenceTime);
   }).toList()
-    ..sort((a, b) => a.date.compareTo(b.date));
+    ..sort((a, b) {
+      final dateCompare = a.date.compareTo(b.date);
+      if (dateCompare != 0) return dateCompare;
+      return a.startTime.compareTo(b.startTime);
+    });
 
   return filtered.take(count).toList();
 }

--- a/frontend/lib/pages/home/widgets/today_lectures.dart
+++ b/frontend/lib/pages/home/widgets/today_lectures.dart
@@ -56,7 +56,6 @@ class _TodayLecturesState extends State<TodayLectures> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    int idx = 0;
 
     return HomeSection(
       title: l10n.recentLecture,
@@ -102,6 +101,7 @@ class _TodayLecturesState extends State<TodayLectures> {
             );
           }
 
+          int idx = 0;
           // Group those lectures by date
           Map<DateTime, List<LectureModel>> groups = groupBy(
             lectures,

--- a/frontend/lib/pages/lecturer/lecturer_selection_page.dart
+++ b/frontend/lib/pages/lecturer/lecturer_selection_page.dart
@@ -2,9 +2,9 @@
 // Przyjmuje gotową listę [LecturerItem] z zewnątrz i zwraca wybrany element przez [onContinue].
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:lucide_icons/lucide_icons.dart';
 import 'package:plan_pm/api/models/lecturer_item.dart';
 import 'package:plan_pm/global/theme/colors.dart';
+import 'package:plan_pm/global/widgets/back_button.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 import 'package:plan_pm/pages/lecturer/widgets/lecturer_search_field.dart';
 import 'package:plan_pm/pages/lecturer/widgets/lecturer_tile.dart';
@@ -52,14 +52,8 @@ class _LecturerSelectionPageState extends State<LecturerSelectionPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.fromLTRB(8, 8, 24, 0),
-              child: IconButton(
-                onPressed: () => Navigator.pop(context),
-                icon: Icon(
-                  LucideIcons.chevronLeft,
-                  color: AppColor.onBackgroundVariant,
-                ),
-              ),
+              padding: const EdgeInsets.only(top: 8),
+              child: SizedBox(width: 56, child: AppBackButton()),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),

--- a/frontend/lib/pages/settings/widgets/info/role_info.dart
+++ b/frontend/lib/pages/settings/widgets/info/role_info.dart
@@ -26,12 +26,10 @@ class RoleInfo extends StatefulWidget {
 class _RoleInfoState extends State<RoleInfo> {
   Future<void> _switchToStudent() async {
     HapticFeedback.lightImpact();
-    await AppModeManager.setMode(AppMode.student);
-    sevenDayModeNotifier.value = false;
     if (!mounted) return;
     Navigator.push(
       context,
-      appRoute((_) => const InputPage()),
+      appRoute((_) => const InputPage(isRoleSwitch: true)),
     );
   }
 

--- a/frontend/lib/pages/settings/widgets/info/role_info.dart
+++ b/frontend/lib/pages/settings/widgets/info/role_info.dart
@@ -62,6 +62,7 @@ class _RoleInfoState extends State<RoleInfo> {
 
             await DatabaseService.instance.clearLectures();
             await CacheService().syncLectures();
+            await CacheService().syncNews();
 
             if (!mounted) return;
             Navigator.of(

--- a/frontend/lib/pages/welcome/group_selection_page.dart
+++ b/frontend/lib/pages/welcome/group_selection_page.dart
@@ -12,6 +12,8 @@ import 'package:plan_pm/global/widgets/states/generic_no_resource.dart';
 import 'package:plan_pm/pages/home/home_shell.dart';
 import 'package:plan_pm/pages/welcome/widgets/group_builder.dart';
 import 'package:plan_pm/pages/welcome/widgets/onboarding_action_bar.dart';
+import 'package:plan_pm/global/models/app_mode.dart';
+import 'package:plan_pm/global/notifiers/notifiers.dart';
 import 'package:plan_pm/service/backend_service.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:plan_pm/service/cache_service.dart';
@@ -19,7 +21,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 
 class GroupSelectionPage extends StatelessWidget {
-  const GroupSelectionPage({super.key});
+  const GroupSelectionPage({super.key, this.isRoleSwitch = false});
+
+  final bool isRoleSwitch;
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +37,13 @@ class GroupSelectionPage extends StatelessWidget {
           FloatingActionButtonLocation.miniCenterFloat,
       floatingActionButton: OnboardingActionBar(
         skipLabel: l10n.skipButton,
-        onSkip: () {
+        onSkip: () async {
           HapticFeedback.lightImpact();
+          if (isRoleSwitch) {
+            await AppModeManager.setMode(AppMode.student);
+            sevenDayModeNotifier.value = false;
+          }
+          if (!context.mounted) return;
           Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(
@@ -46,6 +55,10 @@ class GroupSelectionPage extends StatelessWidget {
         confirmLabel: l10n.save,
         onConfirm: () async {
           HapticFeedback.lightImpact();
+          if (isRoleSwitch) {
+            await AppModeManager.setMode(AppMode.student);
+            sevenDayModeNotifier.value = false;
+          }
           final SharedPreferences prefs = await SharedPreferences.getInstance();
           await prefs.setStringList("groups", Student.selectedGroups ?? []);
           await CacheService().syncNews();

--- a/frontend/lib/pages/welcome/input_page.dart
+++ b/frontend/lib/pages/welcome/input_page.dart
@@ -23,7 +23,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 typedef UniversityData = Map<String, Map<String, List<String>>>;
 
 class InputPage extends StatefulWidget {
-  const InputPage({super.key});
+  const InputPage({super.key, this.isRoleSwitch = false});
+
+  final bool isRoleSwitch;
 
   @override
   State<InputPage> createState() => _InputPageState();
@@ -96,12 +98,16 @@ class _InputPageState extends State<InputPage> {
         skipLabel: l10n.skipButton,
         onSkip: () {
           HapticFeedback.lightImpact();
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MyHomePage(title: "Plan PM"),
-            ),
-          );
+          if (widget.isRoleSwitch) {
+            Navigator.pop(context);
+          } else {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (context) => const MyHomePage(title: "Plan PM"),
+              ),
+            );
+          }
         },
         confirmLabel: l10n.groupSelection,
         onConfirm: _canProceed
@@ -149,7 +155,9 @@ class _InputPageState extends State<InputPage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => GroupSelectionPage(),
+                    builder: (context) => GroupSelectionPage(
+                      isRoleSwitch: widget.isRoleSwitch,
+                    ),
                   ),
                 );
               }

--- a/frontend/lib/pages/welcome/role_selection_page.dart
+++ b/frontend/lib/pages/welcome/role_selection_page.dart
@@ -109,6 +109,7 @@ class RoleSelectionPage extends StatelessWidget {
 
                           await DatabaseService.instance.clearLectures();
                           await CacheService().syncLectures();
+                          await CacheService().syncNews();
 
                           if (!context.mounted) return;
                           Navigator.of(

--- a/frontend/lib/service/database_service.dart
+++ b/frontend/lib/service/database_service.dart
@@ -149,7 +149,10 @@ class DatabaseService {
 
   Future<List<LectureModel>> fetchLectures() async {
     final db = await database;
-    final data = await db.query(_lecturesTableName);
+    final data = await db.query(
+      _lecturesTableName,
+      orderBy: '$_lecturesDateColumnName ASC, $_lecturesStartTimeColumnName ASC',
+    );
     return data.map((row) {
       final date = DateTime.fromMillisecondsSinceEpoch(
         row[_lecturesDateColumnName] as int,


### PR DESCRIPTION
## Summary

### Lecture card colors shuffling on pull-to-refresh
**Root cause:** `int idx = 0` was declared in `_TodayLecturesState.build()` and captured by the `FutureBuilder` builder closure. The stale-while-revalidate pattern causes the builder to be invoked twice without the parent rebuilding — once for cached (stale) data and once when the new future resolves. The first invocation incremented `idx` to 3, so the second invocation assigned gradient indices 3/4/5 to lectures instead of 0/1/2, producing different colors.

**Fix:** Moved `int idx = 0` inside the `FutureBuilder` builder callback so it resets to zero on every invocation. Also added `ORDER BY date ASC, start_time ASC` to `DatabaseService.fetchLectures()` and a secondary `startTime` sort key in `lecture_filters.dart` for extra consistency.

### Role switch crash when pressing Skip on InputPage
**Root cause:** `_switchToStudent()` in `role_info.dart` called `AppModeManager.setMode(AppMode.student)` immediately on navigation, before the user confirmed anything. Pressing Skip on `InputPage` sent the user to `MyHomePage` while the app was already in student mode but with no student data configured.

**Fix:** Removed the premature mode change from `_switchToStudent()`. Added an `isRoleSwitch` flag threaded through `InputPage` → `GroupSelectionPage`. When `isRoleSwitch = true`, Skip on `InputPage` pops back (cancels the switch), and the mode change only happens in `GroupSelectionPage`'s `onSkip`/`onConfirm` callbacks — after the user has committed to switching.

### RefreshIndicator appearing behind the floating AppBar
**Root cause:** Default `edgeOffset: 0` placed the spinner at the top of the scrollable, which is behind the blur AppBar.

**Fix:** Set `edgeOffset: MediaQuery.of(context).padding.top + kToolbarHeight` to push the spinner below the AppBar.

### Bottom nav bar border picking up content colors
**Root cause:** The `BorderSide` was rendered inside `ClipRect`/`BackdropFilter`, so its color blended with the blurred background behind the bar.

**Fix:** Moved the border `Container` outside the `BackdropFilter` so it always renders with a solid `AppColor.outline`.

### Frosted glass background bleed-through in light mode
**Root cause:** Both AppBar and BottomNavBar used `alpha: 0.5` regardless of theme brightness. In light mode the semi-transparent white background allowed shadows and card edges to bleed through visibly.

**Fix:** Background alpha is now brightness-aware — `0.92` in light mode, `0.5` in dark mode — applied consistently to both bars.

### LecturerSelectionPage back button not using glass style on iOS
**Fix:** Replaced the plain `IconButton` with `AppBackButton`, which already handles platform-specific rendering (glass `CNButton` on iOS, `IconButton` on Android).

## Test plan
- [ ] Pull-to-refresh on home screen — lecture card colors must stay the same after refresh
- [ ] Lecturer switching to student mode → pressing Skip on InputPage must pop back to Settings without any mode change
- [ ] Lecturer switching to student mode → completing the full flow must switch the app to student mode
- [ ] Pull-to-refresh spinner appears below the AppBar, not behind it
- [ ] Bottom nav bar top border is a consistent solid color regardless of content behind the bar
- [ ] Light mode: AppBar and BottomNavBar have no visible content bleed-through
- [ ] Dark mode: frosted glass blur effect still visible on both bars
- [ ] LecturerSelectionPage shows glass back button on iOS, standard chevron on Android