### PR TITLE
fix: correctly split combined lecturers with maritime captain title (kpt. ż. w.)

### DIFF
--- a/backend/parser/parser.py
+++ b/backend/parser/parser.py
@@ -15,8 +15,6 @@ MAP = {"Plan dla toku" : "program", "Przedmiot" : "subject", "Grupy" : "group", 
 
 DEBUG = False
 
-DEBUG = True
-
 ### DEBUG TOOL
 def printTok(tok):
     if not DEBUG:
@@ -194,9 +192,23 @@ class Parser:
         prof = teacher.find("prof. ", 1)
         dr = teacher.find("dr ", 7)
         mgr = teacher.find("mgr ", 1)
-    
+
+        # "kpt. ż. w." is a maritime title that can appear both as part of a compound
+        # academic title (e.g. "mgr inż. kpt. ż. w.") and as a standalone title for
+        # a second teacher. Distinguish by checking what precedes it:
+        # - preceded by '.' → part of compound title → find second occurrence
+        # - preceded by a name word (no dot) → starts a new teacher
+        first_kpt = teacher.find("kpt. ")
+        if first_kpt == -1:
+            kpt = -1
+        elif first_kpt == 0:
+            kpt = teacher.find("kpt. ", 5)
+        else:
+            before = teacher[:first_kpt].rstrip()
+            kpt = teacher.find("kpt. ", first_kpt + 5) if before.endswith('.') else first_kpt
+
         t = []
-    
+
         if prof != -1:
             t += self.parseTeachers(teacher[prof:])
             teacher = teacher[:prof]
@@ -206,9 +218,12 @@ class Parser:
         elif mgr != -1:
             t += (self.parseTeachers(teacher[mgr:]))
             teacher = teacher[:mgr]
-    
+        elif kpt != -1:
+            t += (self.parseTeachers(teacher[kpt:]))
+            teacher = teacher[:kpt]
+
         t.append(teacher.strip())
-    
+
         return t
 
     @staticmethod

--- a/backend/parser/test_parser.py
+++ b/backend/parser/test_parser.py
@@ -107,6 +107,42 @@ def test_parseTeachers_empty():
     assert p.parseTeachers("") == []
 
 
+def test_parseTeachers_kpt_compound_title_splits_correctly():
+    """Both teachers have 'mgr inż. kpt. ż. w.' — compound title should not split on the first kpt."""
+    p = Parser.__new__(Parser)
+    result = p.parseTeachers(
+        "mgr inż. kpt. ż. w. Tomasz Pluta mgr inż. kpt. ż. w. Barbara Kwiecińska"
+    )
+    assert len(result) == 2
+    assert any("Tomasz Pluta" in r for r in result)
+    assert any("Barbara Kwiecińska" in r for r in result)
+
+
+def test_parseTeachers_kpt_standalone_after_mgr():
+    """Second teacher has only 'kpt. ż. w.' title (no mgr/dr), must still split."""
+    p = Parser.__new__(Parser)
+    result = p.parseTeachers("mgr inż. Jan Kowalski kpt. ż. w. Anna Nowak")
+    assert len(result) == 2
+    assert any("Jan Kowalski" in r for r in result)
+    assert any("Anna Nowak" in r for r in result)
+
+
+def test_parseTeachers_kpt_single_teacher():
+    """Single teacher with kpt. ż. w. title — must NOT split."""
+    p = Parser.__new__(Parser)
+    result = p.parseTeachers("kpt. ż. w. Jan Kowalski")
+    assert result == ["kpt. ż. w. Jan Kowalski"]
+
+
+def test_parseTeachers_kpt_both_standalone():
+    """Both teachers have only 'kpt. ż. w.' — splits on second occurrence."""
+    p = Parser.__new__(Parser)
+    result = p.parseTeachers("kpt. ż. w. Jan Kowalski kpt. ż. w. Anna Nowak")
+    assert len(result) == 2
+    assert any("Jan Kowalski" in r for r in result)
+    assert any("Anna Nowak" in r for r in result)
+
+
 # --- Testy dla tokStringToDic ---
 
 def test_tokStringToDic_standard():


### PR DESCRIPTION
## Summary

### Bug 1 — Combined lecturers with `kpt. ż. w.` title were not split correctly

`parseTeachers()` splits a combined teacher string by searching for academic title prefixes (`prof.`, `dr`, `mgr`) starting from position 1 to skip the first title. This works correctly when both lecturers hold a standard academic title.

**Problem:** The maritime captain title (`kpt. ż. w.` — kapitan żeglugi wielkiej) is not one of the recognized split points. For a string like:

```
"mgr inż. kpt. ż. w. Tomasz Pluta mgr inż. kpt. ż. w. Barbara Kwiecińska"
```

The function found the second `mgr` correctly. But for a case where the second teacher holds *only* the `kpt. ż. w.` title with no `mgr`/`dr`/`prof.` prefix:

```
"mgr inż. Jan Kowalski kpt. ż. w. Anna Nowak"
```

No split point was found → both names were stored as a single combined entry in the `teachers` table → `teachersclasses` linked that combined entry to the class, not the individual teachers → **neither lecturer could find the combined class by selecting themselves**.

**Fix:** Added `kpt.` detection in `parseTeachers()`. The tricky part is that `kpt.` can appear both *inside* a compound title (e.g. `mgr inż. kpt. ż. w.`) and as the *start* of a new teacher's title. The logic distinguishes them by checking the character before the match:
- preceded by `.` → part of a compound title → search for the second occurrence
- preceded by a name word (no `.`) → start of a new teacher → split here

### Bug 2 — Accidental `DEBUG = True` override

A stray `DEBUG = True` line was present directly below `DEBUG = False`, silently overriding it and making the parser print verbose output on every run. Removed.

---

## Legacy data note — rooms with commas in the database

After running the fixed pipeline against the test DB, several rooms appeared with commas in their names (e.g. `"122,Willowa B4 107"`, `"5,Żołnierska 5"`). This is **not a new bug** introduced by this PR.

These entries originated from an older production pipeline run where the parser stored un-split room strings. The current `parseRooms()` already handles the scraper's `\xa0, ` separator correctly — Python's `strip()` removes the non-breaking space and the split on `", "` produces clean room names. The problematic entries were legacy artifacts carried over during a production → test DB sync and **not overwritten** because `json2db` runs as an upsert by default.

**Resolution on test DB:** Re-ran `json2db --clear` to wipe stale data and reload from the current parser output. All rooms now clean — the only comma-room remaining is `"14,15"` which is a legitimate combined room name.

**Action needed on production DB:** The same legacy rooms likely exist in production. They should be cleaned up either by running the full pipeline with `--clear` on the next scheduled sync, or by a targeted SQL migration.

---

## Tests

Added 4 new test cases in `test_parser.py` covering all `kpt. ż. w.` scenarios:

- Both teachers have compound `mgr inż. kpt. ż. w.` title — must not split on the first `kpt.`
- Second teacher has standalone `kpt. ż. w.` (no `mgr`/`dr`) — must split
- Single teacher with `kpt. ż. w.` — must NOT split
- Both teachers have standalone `kpt. ż. w.` — splits on the second occurrence

All 15 tests pass.