### PR TITLE
Fix: prevent duplicate lectures from rapid taps during onboarding

### DIFF
--- a/frontend/lib/pages/welcome/group_selection_page.dart
+++ b/frontend/lib/pages/welcome/group_selection_page.dart
@@ -20,16 +20,69 @@ import 'package:plan_pm/service/cache_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 
-class GroupSelectionPage extends StatelessWidget {
+class GroupSelectionPage extends StatefulWidget {
   const GroupSelectionPage({super.key, this.isRoleSwitch = false});
 
   final bool isRoleSwitch;
 
   @override
+  State<GroupSelectionPage> createState() => _GroupSelectionPageState();
+}
+
+class _GroupSelectionPageState extends State<GroupSelectionPage> {
+  final BackendService _backendService = BackendService();
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Student.selectedGroups = [];
+  }
+
+  Future<void> _handleConfirm() async {
+    setState(() => _isSubmitting = true);
+    try {
+      HapticFeedback.lightImpact();
+      if (widget.isRoleSwitch) {
+        await AppModeManager.setMode(AppMode.student);
+        sevenDayModeNotifier.value = false;
+      }
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList("groups", Student.selectedGroups ?? []);
+      await CacheService().syncNews();
+      await CacheService().syncLectures();
+      if (!mounted) return;
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const MyHomePage(title: "Plan PM"),
+        ),
+        (r) => false,
+      );
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  Future<void> _handleSkip() async {
+    HapticFeedback.lightImpact();
+    if (widget.isRoleSwitch) {
+      await AppModeManager.setMode(AppMode.student);
+      sevenDayModeNotifier.value = false;
+    }
+    if (!mounted) return;
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const MyHomePage(title: "Plan PM"),
+      ),
+      (r) => false,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final backendService = BackendService();
-    Student.selectedGroups = [];
     return Scaffold(
       backgroundColor: AppColor.background,
       appBar: CustomAppBar(title: l10n.groupSettings),
@@ -37,41 +90,9 @@ class GroupSelectionPage extends StatelessWidget {
           FloatingActionButtonLocation.miniCenterFloat,
       floatingActionButton: OnboardingActionBar(
         skipLabel: l10n.skipButton,
-        onSkip: () async {
-          HapticFeedback.lightImpact();
-          if (isRoleSwitch) {
-            await AppModeManager.setMode(AppMode.student);
-            sevenDayModeNotifier.value = false;
-          }
-          if (!context.mounted) return;
-          Navigator.pushAndRemoveUntil(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MyHomePage(title: "Plan PM"),
-            ),
-            (r) => false,
-          );
-        },
+        onSkip: _handleSkip,
         confirmLabel: l10n.save,
-        onConfirm: () async {
-          HapticFeedback.lightImpact();
-          if (isRoleSwitch) {
-            await AppModeManager.setMode(AppMode.student);
-            sevenDayModeNotifier.value = false;
-          }
-          final SharedPreferences prefs = await SharedPreferences.getInstance();
-          await prefs.setStringList("groups", Student.selectedGroups ?? []);
-          await CacheService().syncNews();
-          await CacheService().syncLectures();
-          if (!context.mounted) return;
-          Navigator.pushAndRemoveUntil(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MyHomePage(title: "Plan PM"),
-            ),
-            (r) => false,
-          );
-        },
+        onConfirm: _isSubmitting ? null : _handleConfirm,
       ),
       body: Padding(
         padding: const EdgeInsets.all(12.0),
@@ -87,7 +108,7 @@ class GroupSelectionPage extends StatelessWidget {
                 ),
               ),
               FutureBuilder(
-                future: backendService.fetchGroups(),
+                future: _backendService.fetchGroups(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return Container(

--- a/frontend/lib/pages/welcome/input_page.dart
+++ b/frontend/lib/pages/welcome/input_page.dart
@@ -47,6 +47,7 @@ class _InputPageState extends State<InputPage> {
   final _backendService = BackendService();
 
   late Future<UniversityData> _futureUniversityStructure;
+  bool _isSubmitting = false;
 
   // Formularz jest gotowy gdy wybrano wydział, kierunek, rok (!=0), tryb i stopień.
   // Specjalizacja jest opcjonalna — pojawia się jeśli backend ją zwraca.
@@ -110,56 +111,62 @@ class _InputPageState extends State<InputPage> {
           }
         },
         confirmLabel: l10n.groupSelection,
-        onConfirm: _canProceed
+        onConfirm: (_canProceed && !_isSubmitting)
             ? () async {
-                HapticFeedback.lightImpact();
-                Student.degreeCourse = selectedDegreeCourse.isNotEmpty
-                    ? selectedDegreeCourse
-                    : null;
-                Student.faculty = selectedFaculty.isNotEmpty
-                    ? selectedFaculty
-                    : null;
-                Student.specialisation = selectedSpecialisation.isNotEmpty
-                    ? selectedSpecialisation
-                    : null;
-                Student.studyMode = selectedTerm == 1
-                    ? StudyMode.stationary
-                    : StudyMode.notStationary;
-                Student.degreeLevel = selectedDegreeLevel == 1 ? "inż." : "mgr";
-                Student.year = selectedYear;
+                setState(() => _isSubmitting = true);
+                try {
+                  HapticFeedback.lightImpact();
+                  Student.degreeCourse = selectedDegreeCourse.isNotEmpty
+                      ? selectedDegreeCourse
+                      : null;
+                  Student.faculty = selectedFaculty.isNotEmpty
+                      ? selectedFaculty
+                      : null;
+                  Student.specialisation = selectedSpecialisation.isNotEmpty
+                      ? selectedSpecialisation
+                      : null;
+                  Student.studyMode = selectedTerm == 1
+                      ? StudyMode.stationary
+                      : StudyMode.notStationary;
+                  Student.degreeLevel =
+                      selectedDegreeLevel == 1 ? "inż." : "mgr";
+                  Student.year = selectedYear;
 
-                final SharedPreferences prefs =
-                    await SharedPreferences.getInstance();
-                await prefs.setString("course", Student.course ?? "");
-                await prefs.setString("faculty", Student.faculty ?? "");
-                await prefs.setString(
-                  "degree_course",
-                  Student.degreeCourse ?? "",
-                );
-                await prefs.setString(
-                  "specialisation",
-                  Student.specialisation ?? "",
-                );
-                await prefs.setInt("year", selectedYear);
-                await prefs.setString(
-                  "study_mode",
-                  Student.studyMode?.programType ?? "S",
-                );
-                await prefs.setString(
-                  "degree_level",
-                  selectedDegreeLevel == 1 ? "inż." : "mgr",
-                );
-                await CacheService().syncNews();
-                await CacheService().syncLectures();
-                if (!context.mounted) return;
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => GroupSelectionPage(
-                      isRoleSwitch: widget.isRoleSwitch,
+                  final SharedPreferences prefs =
+                      await SharedPreferences.getInstance();
+                  await prefs.setString("course", Student.course ?? "");
+                  await prefs.setString("faculty", Student.faculty ?? "");
+                  await prefs.setString(
+                    "degree_course",
+                    Student.degreeCourse ?? "",
+                  );
+                  await prefs.setString(
+                    "specialisation",
+                    Student.specialisation ?? "",
+                  );
+                  await prefs.setInt("year", selectedYear);
+                  await prefs.setString(
+                    "study_mode",
+                    Student.studyMode?.programType ?? "S",
+                  );
+                  await prefs.setString(
+                    "degree_level",
+                    selectedDegreeLevel == 1 ? "inż." : "mgr",
+                  );
+                  await CacheService().syncNews();
+                  await CacheService().syncLectures();
+                  if (!context.mounted) return;
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => GroupSelectionPage(
+                        isRoleSwitch: widget.isRoleSwitch,
+                      ),
                     ),
-                  ),
-                );
+                  );
+                } finally {
+                  if (mounted) setState(() => _isSubmitting = false);
+                }
               }
             : null,
       ),

--- a/frontend/lib/service/cache_service.dart
+++ b/frontend/lib/service/cache_service.dart
@@ -14,7 +14,19 @@ class CacheService {
 
   final BackendService _backendService = BackendService();
 
-  Future<void> syncLectures() async {
+  // Re-entrancy guards: równoległe wywołania zwracają to samo Future
+  // zamiast startować kolejny sync (który by się przeplatał z bieżącym i
+  // produkował duplikaty po `clearLectures` + insert loop).
+  Future<void>? _lecturesSync;
+  Future<void>? _newsSync;
+
+  Future<void> syncLectures() {
+    return _lecturesSync ??= _runLecturesSync().whenComplete(() {
+      _lecturesSync = null;
+    });
+  }
+
+  Future<void> _runLecturesSync() async {
     var lectures = await _backendService.fetchLectures();
     if (lectures.isEmpty) {
       AppLogger.w(
@@ -49,7 +61,13 @@ class CacheService {
     }
   }
 
-  Future<void> syncNews() async {
+  Future<void> syncNews() {
+    return _newsSync ??= _runNewsSync().whenComplete(() {
+      _newsSync = null;
+    });
+  }
+
+  Future<void> _runNewsSync() async {
     AppLogger.i("[CACHE-SERVICE] syncNews — start");
     final news = await _backendService.fetchNews();
     if (news.isEmpty) {


### PR DESCRIPTION
## Summary

Naprawa buga, w którym przy słabym łączu wielokrotne naciśnięcie przycisku \"Zapisz\" / \"Przejdź do wyboru grupy\" w onboardingu powodowało **zwielokrotnienie liczby zajęć** w bazie SQLite — tyle razy, ile razy użytkownik kliknął.

## Przyczyna źródłowa

Dwa równoległe `CacheService().syncLectures()` przeplatały się: każde wywołanie robi `clearLectures()` + pętlę `addLecture()` na auto-incremented ID. Gdy oba pobiorą dane z backendu, oba wywołają `clearLectures()`, a potem oba wstawiają w pętli — wynik to N × liczba zajęć.

Przyczyna w UI: [`OnboardingActionBar`](frontend/lib/pages/welcome/widgets/onboarding_action_bar.dart) odpala każde tapnięcie gdy `onConfirm != null`. [`GroupSelectionPage`](frontend/lib/pages/welcome/group_selection_page.dart) był `StatelessWidget` bez ochrony. [`InputPage`](frontend/lib/pages/welcome/input_page.dart) ma flagę `_canProceed` ale nie blokuje po pierwszym tapnięciu.

## Naprawa (dwie warstwy)

### Warstwa 1 — blokada przycisku w UI

- **`lib/pages/welcome/group_selection_page.dart`** — konwersja `StatelessWidget` → `StatefulWidget`, dodanie `bool _isSubmitting`. Po pierwszym tapnięciu `onConfirm: null` → `OnboardingActionBar` automatycznie wyszarza przycisk (`disabledBackgroundColor`).
- **`lib/pages/welcome/input_page.dart`** — dodanie `_isSubmitting` flag łączonej z `_canProceed` w warunku `onConfirm`.
- Oba handlery owinięte w `try/finally` żeby flaga się zresetowała gdy sync rzuci wyjątek (np. przy zerwaniu sieci) — wtedy user może spróbować ponownie po przywróceniu łącza.
- **Skip jest nietknięty** — nie pisze do DB, więc nie potrzebuje guardu.

### Warstwa 2 — re-entrancy guard w `CacheService` (defense in depth)

- **`lib/service/cache_service.dart`** — `syncLectures` i `syncNews` cache'ują aktualnie trwający `Future`. Kolejne wywołania zwracają to samo Future zamiast startować nowy sync. Flaga resetuje się przez `whenComplete`.
- Chroni przed duplikacją również gdy sync wystartuje równolegle z innych części apki (np. role switch + manual refresh + widget push).

## Test plan (QA)

Wszystkie repro **wymagają wolnego łącza** (Network Link Conditioner na macOS, throttling w Chrome DevTools, lub airplane mode włączane mid-flight). Bez throttlingu sync może być za szybki żeby zauważyć interleaving.

### Test 1 — repro przed fixem (sanity check, opcjonalny)

> Przejdź na `main` przed fixem, żeby zobaczyć bug \"na żywo\".

1. Włącz throttling sieci (3G slow)
2. Świeża instalacja apki → wybór roli → student → InputPage
3. Wypełnij wszystkie pola
4. Tapnij \"Przejdź do wyboru grupy\" **3-4 razy szybko**
5. Po przejściu do GroupSelection — wybierz grupy, tapnij \"Zapisz\" **3-4 razy szybko**
6. Wejdź na home/lectures → liczba zajęć powinna być **wielokrotnością** rzeczywistej liczby

### Test 2 — sprawdzenie fixu (główny)

1. Włącz throttling sieci
2. Świeża instalacja apki (lub Settings → reset profilu) → InputPage
3. Wypełnij dane
4. Tapnij \"Przejdź do wyboru grupy\" **3-5 razy szybko**
   - ✅ Przycisk powinien **wyszarzyć się** po pierwszym tapnięciu i nie reagować na kolejne
5. Na GroupSelection — wybierz grupy
6. Tapnij \"Zapisz\" **3-5 razy szybko**
   - ✅ Ten sam efekt — wyszarzenie po pierwszym
7. Wejdź na lectures → liczba zajęć powinna być **identyczna** z tym co backend zwraca dla tej grupy/profilu
8. Wejdź na home → te same dane (nie podwojone)

### Test 3 — recovery po błędzie sieci

1. **Wyłącz internet całkowicie** (airplane mode)
2. InputPage → wypełnij → tapnij \"Przejdź do wyboru grupy\"
3. Sync rzuca błąd
4. ✅ Przycisk powinien **wrócić do enabled** (try/finally resetuje flagę)
5. Włącz internet → tapnij ponownie → flow działa normalnie

### Test 4 — switch roli (defense in depth)

1. Po dotychczasowym onboardingu jako student → Settings → przełącz na wykładowcę
2. Wybierz wykładowcę → po zapisie sync leci
3. Tapnij ponownie ten sam wybór szybko
4. ✅ Tylko jeden sync — w logach `[CACHE-SERVICE] syncLectures` (i syncNews) startuje raz na cały burst

### Test 5 — normalny onboarding (regresja)

1. Z normalnym łączem przejdź onboarding student od początku do końca
2. ✅ Wszystko działa jak zwykle, zajęcia są raz w DB, nawigacja przechodzi do home

### Test 6 — sanity check na obu platformach

1. **iOS**: `flutter run --device-id <iphone>` — wszystkie powyższe testy
2. **Android**: `flutter run --device-id <android>` — wszystkie powyższe testy
3. ✅ Brak różnic w zachowaniu między platformami (logika jest w Dart, nie natywna)

## Out of scope (do osobnego PR jeśli okaże się potrzebne)

- **`onSkip` w `GroupSelectionPage`/`InputPage`** — nie pisze do DB, więc bezpieczny przy wielokrotnym tapnięciu. Można dla spójności dodać guard, ale niski priorytet.
- **Lecturer onboarding** ([`lib/pages/lecturer/lecturer_selection_page.dart`](frontend/lib/pages/lecturer/lecturer_selection_page.dart)) i przełączanie roli w settings — wywołują `syncLectures()` więc warstwa 2 (guard w `CacheService`) ich obroni. Można dodatkowo zablokować przycisk w UI w przyszłym PR.
- **Wskaźnik ładowania na przycisku** podczas `_isSubmitting` — można rozszerzyć `OnboardingActionBar` o opcjonalny `isLoading` parametr, ale wyszarzenie + brak reakcji jest wystarczająco wyraźne.

## Uwaga dla reviewera

Autor PR nie testował jeszcze ręcznie — fix wynika z analizy kodu, oczekuję że QA sprawdzi czy nie ma regresji w normalnym (szybkie łącze) flow.