### PR TITLE
Fix: prevent duplicate lectures from rapid taps during onboarding

### DIFF
--- a/frontend/lib/pages/welcome/group_selection_page.dart
+++ b/frontend/lib/pages/welcome/group_selection_page.dart
@@ -20,16 +20,69 @@ import 'package:plan_pm/service/cache_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:plan_pm/l10n/app_localizations.dart';
 
-class GroupSelectionPage extends StatelessWidget {
+class GroupSelectionPage extends StatefulWidget {
   const GroupSelectionPage({super.key, this.isRoleSwitch = false});
 
   final bool isRoleSwitch;
 
   @override
+  State<GroupSelectionPage> createState() => _GroupSelectionPageState();
+}
+
+class _GroupSelectionPageState extends State<GroupSelectionPage> {
+  final BackendService _backendService = BackendService();
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Student.selectedGroups = [];
+  }
+
+  Future<void> _handleConfirm() async {
+    setState(() => _isSubmitting = true);
+    try {
+      HapticFeedback.lightImpact();
+      if (widget.isRoleSwitch) {
+        await AppModeManager.setMode(AppMode.student);
+        sevenDayModeNotifier.value = false;
+      }
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList("groups", Student.selectedGroups ?? []);
+      await CacheService().syncNews();
+      await CacheService().syncLectures();
+      if (!mounted) return;
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const MyHomePage(title: "Plan PM"),
+        ),
+        (r) => false,
+      );
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  Future<void> _handleSkip() async {
+    HapticFeedback.lightImpact();
+    if (widget.isRoleSwitch) {
+      await AppModeManager.setMode(AppMode.student);
+      sevenDayModeNotifier.value = false;
+    }
+    if (!mounted) return;
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const MyHomePage(title: "Plan PM"),
+      ),
+      (r) => false,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final backendService = BackendService();
-    Student.selectedGroups = [];
     return Scaffold(
       backgroundColor: AppColor.background,
       appBar: CustomAppBar(title: l10n.groupSettings),
@@ -37,41 +90,9 @@ class GroupSelectionPage extends StatelessWidget {
           FloatingActionButtonLocation.miniCenterFloat,
       floatingActionButton: OnboardingActionBar(
         skipLabel: l10n.skipButton,
-        onSkip: () async {
-          HapticFeedback.lightImpact();
-          if (isRoleSwitch) {
-            await AppModeManager.setMode(AppMode.student);
-            sevenDayModeNotifier.value = false;
-          }
-          if (!context.mounted) return;
-          Navigator.pushAndRemoveUntil(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MyHomePage(title: "Plan PM"),
-            ),
-            (r) => false,
-          );
-        },
+        onSkip: _handleSkip,
         confirmLabel: l10n.save,
-        onConfirm: () async {
-          HapticFeedback.lightImpact();
-          if (isRoleSwitch) {
-            await AppModeManager.setMode(AppMode.student);
-            sevenDayModeNotifier.value = false;
-          }
-          final SharedPreferences prefs = await SharedPreferences.getInstance();
-          await prefs.setStringList("groups", Student.selectedGroups ?? []);
-          await CacheService().syncNews();
-          await CacheService().syncLectures();
-          if (!context.mounted) return;
-          Navigator.pushAndRemoveUntil(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MyHomePage(title: "Plan PM"),
-            ),
-            (r) => false,
-          );
-        },
+        onConfirm: _isSubmitting ? null : _handleConfirm,
       ),
       body: Padding(
         padding: const EdgeInsets.all(12.0),
@@ -87,7 +108,7 @@ class GroupSelectionPage extends StatelessWidget {
                 ),
               ),
               FutureBuilder(
-                future: backendService.fetchGroups(),
+                future: _backendService.fetchGroups(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return Container(

--- a/frontend/lib/pages/welcome/input_page.dart
+++ b/frontend/lib/pages/welcome/input_page.dart
@@ -47,6 +47,7 @@ class _InputPageState extends State<InputPage> {
   final _backendService = BackendService();
 
   late Future<UniversityData> _futureUniversityStructure;
+  bool _isSubmitting = false;
 
   // Formularz jest gotowy gdy wybrano wydział, kierunek, rok (!=0), tryb i stopień.
   // Specjalizacja jest opcjonalna — pojawia się jeśli backend ją zwraca.
@@ -110,56 +111,62 @@ class _InputPageState extends State<InputPage> {
           }
         },
         confirmLabel: l10n.groupSelection,
-        onConfirm: _canProceed
+        onConfirm: (_canProceed && !_isSubmitting)
             ? () async {
-                HapticFeedback.lightImpact();
-                Student.degreeCourse = selectedDegreeCourse.isNotEmpty
-                    ? selectedDegreeCourse
-                    : null;
-                Student.faculty = selectedFaculty.isNotEmpty
-                    ? selectedFaculty
-                    : null;
-                Student.specialisation = selectedSpecialisation.isNotEmpty
-                    ? selectedSpecialisation
-                    : null;
-                Student.studyMode = selectedTerm == 1
-                    ? StudyMode.stationary
-                    : StudyMode.notStationary;
-                Student.degreeLevel = selectedDegreeLevel == 1 ? "inż." : "mgr";
-                Student.year = selectedYear;
+                setState(() => _isSubmitting = true);
+                try {
+                  HapticFeedback.lightImpact();
+                  Student.degreeCourse = selectedDegreeCourse.isNotEmpty
+                      ? selectedDegreeCourse
+                      : null;
+                  Student.faculty = selectedFaculty.isNotEmpty
+                      ? selectedFaculty
+                      : null;
+                  Student.specialisation = selectedSpecialisation.isNotEmpty
+                      ? selectedSpecialisation
+                      : null;
+                  Student.studyMode = selectedTerm == 1
+                      ? StudyMode.stationary
+                      : StudyMode.notStationary;
+                  Student.degreeLevel =
+                      selectedDegreeLevel == 1 ? "inż." : "mgr";
+                  Student.year = selectedYear;
 
-                final SharedPreferences prefs =
-                    await SharedPreferences.getInstance();
-                await prefs.setString("course", Student.course ?? "");
-                await prefs.setString("faculty", Student.faculty ?? "");
-                await prefs.setString(
-                  "degree_course",
-                  Student.degreeCourse ?? "",
-                );
-                await prefs.setString(
-                  "specialisation",
-                  Student.specialisation ?? "",
-                );
-                await prefs.setInt("year", selectedYear);
-                await prefs.setString(
-                  "study_mode",
-                  Student.studyMode?.programType ?? "S",
-                );
-                await prefs.setString(
-                  "degree_level",
-                  selectedDegreeLevel == 1 ? "inż." : "mgr",
-                );
-                await CacheService().syncNews();
-                await CacheService().syncLectures();
-                if (!context.mounted) return;
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => GroupSelectionPage(
-                      isRoleSwitch: widget.isRoleSwitch,
+                  final SharedPreferences prefs =
+                      await SharedPreferences.getInstance();
+                  await prefs.setString("course", Student.course ?? "");
+                  await prefs.setString("faculty", Student.faculty ?? "");
+                  await prefs.setString(
+                    "degree_course",
+                    Student.degreeCourse ?? "",
+                  );
+                  await prefs.setString(
+                    "specialisation",
+                    Student.specialisation ?? "",
+                  );
+                  await prefs.setInt("year", selectedYear);
+                  await prefs.setString(
+                    "study_mode",
+                    Student.studyMode?.programType ?? "S",
+                  );
+                  await prefs.setString(
+                    "degree_level",
+                    selectedDegreeLevel == 1 ? "inż." : "mgr",
+                  );
+                  await CacheService().syncNews();
+                  await CacheService().syncLectures();
+                  if (!context.mounted) return;
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => GroupSelectionPage(
+                        isRoleSwitch: widget.isRoleSwitch,
+                      ),
                     ),
-                  ),
-                );
+                  );
+                } finally {
+                  if (mounted) setState(() => _isSubmitting = false);
+                }
               }
             : null,
       ),

--- a/frontend/lib/service/cache_service.dart
+++ b/frontend/lib/service/cache_service.dart
@@ -14,7 +14,19 @@ class CacheService {
 
   final BackendService _backendService = BackendService();
 
-  Future<void> syncLectures() async {
+  // Re-entrancy guards: równoległe wywołania zwracają to samo Future
+  // zamiast startować kolejny sync (który by się przeplatał z bieżącym i
+  // produkował duplikaty po `clearLectures` + insert loop).
+  Future<void>? _lecturesSync;
+  Future<void>? _newsSync;
+
+  Future<void> syncLectures() {
+    return _lecturesSync ??= _runLecturesSync().whenComplete(() {
+      _lecturesSync = null;
+    });
+  }
+
+  Future<void> _runLecturesSync() async {
     var lectures = await _backendService.fetchLectures();
     if (lectures.isEmpty) {
       AppLogger.w(
@@ -49,7 +61,13 @@ class CacheService {
     }
   }
 
-  Future<void> syncNews() async {
+  Future<void> syncNews() {
+    return _newsSync ??= _runNewsSync().whenComplete(() {
+      _newsSync = null;
+    });
+  }
+
+  Future<void> _runNewsSync() async {
     AppLogger.i("[CACHE-SERVICE] syncNews — start");
     final news = await _backendService.fetchNews();
     if (news.isEmpty) {


### PR DESCRIPTION
## Summary

Fix for a bug where, on slow networks, tapping the confirm button several times during onboarding (\"Save\" on group selection / \"Go to group selection\" on faculty input) caused the schedule to be **duplicated N times** in the local SQLite — once per tap.

## Root cause

Two concurrent `CacheService().syncLectures()` calls interleave:
each one runs `clearLectures()` followed by an `addLecture()` loop on
an auto-incremented ID column. If two calls fetch in parallel, both
clear, then both insert in interleaved order → final row count is
N × the real number of lectures.

UI causes:
- [`OnboardingActionBar`](frontend/lib/pages/welcome/widgets/onboarding_action_bar.dart) fires `onConfirm` on every tap as long as it's non-null.
- [`GroupSelectionPage`](frontend/lib/pages/welcome/group_selection_page.dart) was a `StatelessWidget` with no submission state.
- [`InputPage`](frontend/lib/pages/welcome/input_page.dart) had a `_canProceed` validity flag but no \"already submitting\" guard.

## Fix (two layers)

### Layer 1 — UI button lock

- **`lib/pages/welcome/group_selection_page.dart`**: converted `StatelessWidget` → `StatefulWidget`, added `bool _isSubmitting`. After the first tap, `onConfirm` becomes `null`, which `OnboardingActionBar` already renders as a disabled (greyed-out) button.
- **`lib/pages/welcome/input_page.dart`**: added `_isSubmitting` and combined it with the existing `_canProceed` for the `onConfirm` condition.
- Both handlers are wrapped in `try/finally` so the flag resets if the sync throws (e.g. network drops mid-flight) — the user can retry once connectivity returns.
- **Skip button is untouched** — it doesn't write to the DB, so it doesn't need a guard.

### Layer 2 — re-entrancy guard in `CacheService` (defense in depth)

- **`lib/service/cache_service.dart`**: `syncLectures` and `syncNews` now cache the in-flight `Future`. Concurrent callers receive the same `Future` instead of starting a second sync that would race with the first. The cached future is cleared via `whenComplete`.
- Also protects against duplication when sync is triggered concurrently from elsewhere (role switch, manual refresh, widget data push).

## QA test plan

All repros **require a throttled network** (Network Link Conditioner on macOS, Slow 3G in Chrome DevTools, or Airplane Mode toggled mid-flight). Without throttling the sync is too fast for the interleaving to be observable.

### Test 1 — repro before fix (sanity, optional)

> Check out `main` (before fix) to see the bug live.

1. Enable network throttling (Slow 3G)
2. Fresh install → choose role → student → InputPage
3. Fill all fields
4. Tap \"Go to group selection\" **3–5 times rapidly**
5. After navigation, on GroupSelection: pick groups, tap \"Save\" **3–5 times rapidly**
6. Open Home/Lectures → number of lectures is **a multiple** of the real count

### Test 2 — verify the fix (main test)

1. Enable network throttling
2. Fresh install (or Settings → reset profile) → InputPage
3. Fill in the data
4. Tap \"Go to group selection\" **3–5 times rapidly**
   - ✅ The button should **grey out** after the first tap and not respond to further taps
5. On GroupSelection, pick groups
6. Tap \"Save\" **3–5 times rapidly**
   - ✅ Same: greys out after the first tap
7. Open Lectures → count must **match exactly** what the backend returns for that group/profile
8. Open Home → same data, not doubled

### Test 3 — recovery after network error

1. **Disable internet completely** (Airplane Mode)
2. InputPage → fill → tap \"Go to group selection\"
3. Sync throws
4. ✅ The button should **re-enable** (try/finally resets the flag)
5. Re-enable internet → tap again → flow proceeds normally

### Test 4 — role switch (defense-in-depth check)

1. After completing onboarding as a student → Settings → switch to lecturer
2. Pick a lecturer → save triggers a sync
3. Quickly trigger the same action again
4. ✅ Only one sync runs — logs should show `[CACHE-SERVICE] syncLectures` (and `syncNews`) starting once per burst, not N times

### Test 5 — normal onboarding (regression)

1. With a normal network, walk through the student onboarding from scratch
2. ✅ Everything still works as before; the schedule appears once in the DB and navigation lands on Home

### Test 6 — both platforms

1. **iOS**: `flutter run --device-id <iphone>` — run all the above
2. **Android**: `flutter run --device-id <android>` — run all the above
3. ✅ Behaviour should be identical (logic lives in Dart, not native)

## Out of scope (follow-up PRs if needed)

- **`onSkip` in `GroupSelectionPage`/`InputPage`** — does not write to the DB, so it's safe under rapid taps. A consistency guard could be added later but is low-priority.
- **Lecturer onboarding** ([`lib/pages/lecturer/lecturer_selection_page.dart`](frontend/lib/pages/lecturer/lecturer_selection_page.dart)) and the role switch in Settings also call `syncLectures()`. Layer 2 (CacheService guard) already protects them; the UI-level button lock could be applied for consistency in a follow-up.
- **Loading indicator on the button** while `_isSubmitting` is true — could extend `OnboardingActionBar` with an optional `isLoading` parameter. Current grey-out + non-response is already clear enough.

## Note for reviewer

The author has not yet tested this manually — the fix was derived from
a code analysis of the race. QA should specifically watch for any
regression in the happy-path (normal network) onboarding flow.