### PR TITLE
Migrate backend to use Supabase service role key exclusively

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_KEY=<service_role_key>
+
+# Optional – test database
+TEST_SUPABASE_URL=https://<test-project>.supabase.co
+TEST_SUPABASE_SERVICE_KEY=<test_service_role_key>
+TEST_DB_URL=postgresql://postgres.xxxx:password@aws-0-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
+
+IMGBB_API_KEY=<key>

--- a/backend/GEMINI.md
+++ b/backend/GEMINI.md
@@ -1,0 +1,67 @@
+# PlanPM Backend - Project Instructions
+
+## Project Overview
+PlanPM Backend is a Python-based system for fetching, processing, and storing class schedules from the Virtual Dean's Office of the Maritime University of Szczecin into a Supabase database.
+
+### Core Architecture
+The system operates as a multi-stage pipeline:
+1.  **Mapper:** Scans for valid schedule IDs on the university website.
+2.  **Scrapper:** Fetches raw timetable data using either a high-performance HTTP scraper or a Selenium-based fallback.
+3.  **Parser:** Normalizes raw HTML data into structured JSON, handling deduplication, entity extraction (teachers, rooms, subjects), and date conversion.
+4.  **json2db:** Upserts the normalized data into Supabase PostgreSQL tables.
+
+### Key Components
+- `main.py`: The entry point for running the full pipeline.
+- `mapper/`: Schedule ID discovery logic.
+- `scrapper/`: Web scraping implementations (`HttpScrapper` preferred, `Scrapper` for Selenium).
+- `parser/`: Data normalization and transformation logic.
+- `json2db/`: Database upload utility.
+- `structure_updater/`: Independent pipeline for updating the university hierarchy (Faculties → Courses → Specialisations).
+- `news_tool/`: Local Flask-based admin UI for managing news posts displayed in the mobile app.
+- `database_manager/`: Utility for database schema migrations and data synchronization between production and test environments.
+
+## Technologies
+- **Language:** Python 3.13+
+- **Database:** Supabase (PostgreSQL)
+- **Scraping:** Requests, BeautifulSoup4, Selenium (Headless Chrome)
+- **Admin Tool:** Flask, Jinja2, Pillow
+- **Testing:** Pytest
+- **Utilities:** python-dotenv, Rich (logging)
+
+## Development Workflow
+
+### Setup & Configuration
+1.  **Environment:** Create a `.env` file at the root with the following keys:
+    - `SUPABASE_URL`
+    - `SUPABASE_SERVICE_KEY` (Required for all DB operations and news management)
+    - `TEST_SUPABASE_URL`, `TEST_SUPABASE_SERVICE_KEY`, `TEST_DB_URL` (For testing)
+2.  **Mode Switching:** Use `.env_mode` to toggle between `prod` and `test` environments:
+    ```bash
+    echo "test" > .env_mode
+    ```
+3.  **Dependencies:** Managed via `uv` or `pip`. Key dependencies are in `pyproject.toml` and `requirements.txt`.
+
+### Key Commands
+- **Full Pipeline:** `python main.py`
+- **Re-upload Only:** `python uploadparsetodb.py` (Skips scraping, uses existing `output/parser.json`)
+- **University Structure:** `python -m structure_updater.structure_updater`
+- **News Tool:** `python news_tool/app.py`
+- **Database Management:**
+    - `python database_manager/database_manager.py --schema` (Apply schema to test DB)
+    - `python database_manager/database_manager.py --sync` (Sync prod schema and data to test DB)
+
+### Testing Practices
+- **Run Tests:** `pytest`
+- **Fast Tests Only:** `pytest -m "not slow"` (Excludes live network and Selenium tests)
+- **Slow Tests Only:** `pytest -m slow` (Requires browser and internet access)
+- **Coverage:** `pytest --cov=. -m "not slow"`
+
+## Coding Conventions
+- **Module Structure:** Each module (mapper, scrapper, etc.) should re-export its primary class/function in its `__init__.py`.
+- **Logging:** All pipeline steps should log to the `logs/` directory.
+- **Data Output:** Intermediate data should be stored in the `output/` directory as JSON.
+- **Type Safety:** Use type hints wherever possible.
+- **Database Safety:** Prefer upsert operations to handle existing data gracefully.
+
+## Technical Context
+For deep technical details on the DevExpress grid scraping logic, AJAX callbacks, and specific data normalization rules, refer to `docs/agent.md`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -140,12 +140,10 @@ Create a `.env` file in the `backend/` directory:
 
 ```env
 SUPABASE_URL=https://<project>.supabase.co
-SUPABASE_KEY=<anon_key>
-SUPABASE_SERVICE_KEY=<service_role_key>   # required for json2db clear_db and news_tool uploads
+SUPABASE_SERVICE_KEY=<service_role_key>
 
 # Optional – test database (used when .env_mode contains "test")
 TEST_SUPABASE_URL=https://<test-project>.supabase.co
-TEST_SUPABASE_KEY=<test_anon_key>
 TEST_SUPABASE_SERVICE_KEY=<test_service_role_key>
 TEST_DB_URL=postgresql://...              # for direct DB access in slow tests
 ```

--- a/backend/docs/agent.md
+++ b/backend/docs/agent.md
@@ -525,7 +525,7 @@ Both pipelines use `.env` at the backend root:
 
 ```
 SUPABASE_URL=https://...supabase.co
-SUPABASE_KEY=...
+SUPABASE_SERVICE_KEY=...
 ```
 
 Loaded via `python-dotenv`. Missing variables cause an error log and early exit (not an exception) in the main entry points.

--- a/backend/json2db/json2db.py
+++ b/backend/json2db/json2db.py
@@ -49,18 +49,15 @@ class json2db:
     def load_env(self):
         # Load environment variables and create a db connection
         url = os.environ.get(f"{_prefix}SUPABASE_URL")
-        key = os.environ.get(f"{_prefix}SUPABASE_KEY")
         service_key = os.environ.get(f"{_prefix}SUPABASE_SERVICE_KEY")
 
-        if not url or not key:
-            raise EnvironmentError("SUPABASE_URL and SUPABASE_KEY are required. Add them to your .env file.")
-        if not service_key:
-            raise EnvironmentError("SUPABASE_SERVICE_KEY is required for clear_db(). Add it to your .env file.")
+        if not url or not service_key:
+            raise EnvironmentError("SUPABASE_URL and SUPABASE_SERVICE_KEY are required. Add them to your .env file.")
 
         print("Got url: ", url)
 
-        self.db = create_client(url, key)
         self.admin_db = create_client(url, service_key)
+        self.db = self.admin_db
         
     def clear_db(self):
         self.admin_db.table("teachersclasses").delete().neq("id", "00000000-0000-0000-0000-000000000000").execute()

--- a/backend/json2db/test_json2db.py
+++ b/backend/json2db/test_json2db.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import pytest
+from unittest.mock import MagicMock
 from json2db import json2db
 
 INPUT = "./output/parser.json"
@@ -172,3 +173,68 @@ def test_plan_417_rooms_not_willowa(parser_output):
             f"Klasa planu 417 ma salę w Willowej: {room} (budynek: {b_name}). "
             f"Powinno być Żołnierska lub WChrobrego."
         )
+
+def test_load_env_success(monkeypatch, parser_output):
+    import sys
+    from json2db import json2db as j2db
+    import json2db.json2db as j2db_mod
+    
+    # Ensure we are patching the module, not the class
+    target = j2db_mod
+    if not hasattr(target, "create_client"):
+        # Fallback if j2db_mod is the class
+        target = sys.modules["json2db.json2db"]
+
+    mock_create = MagicMock()
+    monkeypatch.setattr(target, "create_client", mock_create)
+    
+    monkeypatch.setenv("SUPABASE_URL", "http://fake-url")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "fake-service-key")
+    
+    # Force _prefix to empty string (prod mode)
+    monkeypatch.setattr(target, "_prefix", "")
+    
+    db = j2db(input=parser_output)
+    db.load_env()
+    
+    assert db.db is not None
+    assert db.admin_db is not None
+    assert db.db is db.admin_db
+    # Verify create_client was called with service key
+    mock_create.assert_called_once_with("http://fake-url", "fake-service-key")
+    
+def test_load_env_test_mode(monkeypatch, parser_output):
+    import sys
+    from json2db import json2db as j2db
+    import json2db.json2db as j2db_mod
+    
+    target = j2db_mod
+    if not hasattr(target, "create_client"):
+        target = sys.modules["json2db.json2db"]
+
+    mock_create = MagicMock()
+    monkeypatch.setattr(target, "create_client", mock_create)
+    
+    monkeypatch.setenv("TEST_SUPABASE_URL", "http://test-url")
+    monkeypatch.setenv("TEST_SUPABASE_SERVICE_KEY", "test-service-key")
+    
+    # Force _prefix to TEST_ by patching the module level variable
+    # Since it's calculated at import time, we need to patch it carefully
+    monkeypatch.setattr(target, "_prefix", "TEST_")
+    
+    db = j2db(input=parser_output)
+    db.load_env()
+    
+    mock_create.assert_called_once_with("http://test-url", "test-service-key")
+
+def test_load_env_missing_service_key(monkeypatch, parser_output):
+    monkeypatch.setenv("SUPABASE_URL", "http://fake-url")
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    monkeypatch.setenv("TEST_SUPABASE_URL", "http://fake-url")
+    monkeypatch.delenv("TEST_SUPABASE_SERVICE_KEY", raising=False)
+    
+    db = json2db(input=parser_output)
+    with pytest.raises(EnvironmentError) as exc_info:
+        db.load_env()
+    assert "SUPABASE_SERVICE_KEY" in str(exc_info.value)
+

--- a/backend/structure_updater/structure_updater.py
+++ b/backend/structure_updater/structure_updater.py
@@ -215,15 +215,13 @@ def main() -> None:
         return
 
     url = os.environ.get(f"{_prefix}SUPABASE_URL")
-    key = os.environ.get(f"{_prefix}SUPABASE_KEY")
     service_key = os.environ.get(f"{_prefix}SUPABASE_SERVICE_KEY")
-    if not url or not key:
-        logger.error("Brak SUPABASE_URL lub SUPABASE_KEY w zmiennych środowiskowych")
-        print("Brak SUPABASE_URL lub SUPABASE_KEY w zmiennych środowiskowych.")
+    if not url or not service_key:
+        logger.error("Brak SUPABASE_URL lub SUPABASE_SERVICE_KEY w zmiennych środowiskowych")
+        print("Brak SUPABASE_URL lub SUPABASE_SERVICE_KEY w zmiennych środowiskowych.")
         return
 
-    db = create_client(url, key)
-    admin_db = create_client(url, service_key) if service_key else db
+    admin_db = create_client(url, service_key)
 
     try:
         clear_structure_tables(admin_db)
@@ -234,7 +232,7 @@ def main() -> None:
             "Failed to clear structure tables. Check Supabase delete policies/RLS."
         ) from exc
 
-    propagate_structure_to_db(db, structure)
+    propagate_structure_to_db(admin_db, structure)
     logger.info("Struktura zaktualizowana w bazie danych")
     print("Structure propagated to Supabase.")
 

--- a/backend/structure_updater/test_structure_updater.py
+++ b/backend/structure_updater/test_structure_updater.py
@@ -272,9 +272,9 @@ def test_main_dry_run_xml(tmp_path, monkeypatch, capsys):
 
 
 def test_main_missing_env_vars(tmp_path, monkeypatch, capsys):
-    """main() bez SUPABASE_URL/KEY drukuje błąd i nie crashuje."""
+    """main() bez SUPABASE_URL/SERVICE_KEY drukuje błąd i nie crashuje."""
     import sys
-    from structure_updater.structure_updater import main
+    from structure_updater import structure_updater as su
 
     xml = tmp_path / "structure.xml"
     xml.write_text(textwrap.dedent("""\
@@ -287,16 +287,24 @@ def test_main_missing_env_vars(tmp_path, monkeypatch, capsys):
     """), encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
+    # Clear all possible env vars
     monkeypatch.delenv("SUPABASE_URL", raising=False)
-    monkeypatch.delenv("SUPABASE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    monkeypatch.delenv("TEST_SUPABASE_URL", raising=False)
+    monkeypatch.delenv("TEST_SUPABASE_SERVICE_KEY", raising=False)
+    
+    # Force _prefix to empty string to be sure
+    monkeypatch.setattr(su, "_prefix", "")
+    
     monkeypatch.setattr(sys, "argv", [
         "structure_updater", "--source", "xml", "--xml-path", str(xml)
     ])
 
-    main()
+    su.main()
 
     output = capsys.readouterr().out
     assert "SUPABASE" in output
+    assert "SERVICE_KEY" in output
 
 
 def test_main_clear_tables_error(tmp_path, monkeypatch):
@@ -315,8 +323,9 @@ def test_main_clear_tables_error(tmp_path, monkeypatch):
     """), encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(su, "_prefix", "")
     monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
-    monkeypatch.setenv("SUPABASE_KEY", "fake-key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "fake-key")
     monkeypatch.setattr(sys, "argv", [
         "structure_updater", "--source", "xml", "--xml-path", str(xml)
     ])

--- a/scripts/switch_env.py
+++ b/scripts/switch_env.py
@@ -29,6 +29,15 @@ ENV_CONFIG_DART.write_text(
     "\n"
     "// Set to true to always show the \"What's new\" dialog (for UI development)\n"
     "const bool kDebugWhatsNew = false;\n"
+    "\n"
+    "// Set to true to return mock news data (bypasses Supabase)\n"
+    "const bool kDebugNews = false;\n"
+    "\n"
+    "// ImgBB URL to use for the mock news image (empty = no image)\n"
+    "const String kDebugNewsImageUrl = \"\";\n"
+    "\n"
+    "// Set to true to always show the rector hours banner (for UI development)\n"
+    "const bool kDebugRectorHours = false;\n"
 )
 
 print(f"Przestawiono na: {mode}")


### PR DESCRIPTION
This PR migrates the backend to use the service role key for all database operations, removing the dependency on the anon key. It includes updates to the data loading pipelines, documentation, and tests.