### PR TITLE
Fix: rector days / cancellations not marked (notes dropped before classification)

### DIFF
--- a/frontend/lib/pages/home/widgets/today_lectures.dart
+++ b/frontend/lib/pages/home/widgets/today_lectures.dart
@@ -143,6 +143,7 @@ class _TodayLecturesState extends State<TodayLectures> {
                         programName: lecture.programName,
                         year: lecture.year,
                         degreeLevel: lecture.degreeLevel,
+                        notes: lecture.notes,
                       );
                     }).toList();
 

--- a/frontend/lib/pages/lectures/lectures_page.dart
+++ b/frontend/lib/pages/lectures/lectures_page.dart
@@ -161,6 +161,7 @@ class _LecturesPageState extends State<LecturesPage> {
                               programName: lecture.programName,
                               year: lecture.year,
                               degreeLevel: lecture.degreeLevel,
+                              notes: lecture.notes,
                             );
                           },
                         ),

--- a/frontend/lib/service/cache_service.dart
+++ b/frontend/lib/service/cache_service.dart
@@ -55,6 +55,7 @@ class CacheService {
         group: lecture.group,
         duration: lecture.duration,
         date: lecture.date,
+        notes: lecture.notes,
         programName: lecture.programName,
         year: lecture.year,
         degreeLevel: lecture.degreeLevel,


### PR DESCRIPTION
## Summary

Rector days, rector hours, and cancellations were never marked in the app, even though the `notes` field (e.g. `Dzień Rektorski`) is present in the database and returned by the `v_lectures` view.

Tracing the data flow showed `notes` was fetched from Supabase and read by `LectureModel`, but **dropped in two places** before it reached the classification logic:

1. **`cache_service.addLecture()`** did not pass `notes`, so the local cache (which the UI reads from) always stored `null` notes.
2. The **`Lecture(...)` widget construction** in `lectures_page.dart` and `today_lectures.dart` did not pass `notes`, so `_determineStatus()` always evaluated an empty string and set `canceledReason = null`.

Both now forward `notes`, so `CanceledReason` (`rectorHours` / `rectorDay` / `canceled`) is classified and rendered correctly.

## Root cause

The whole pipeline already carried `notes` (DB column → `v_lectures` view → `LectureModel.fromJson` → cache read path). Only the two write/construction sites silently omitted the field, so the value never reached `_determineStatus()`.

## Changes

- `lib/service/cache_service.dart` — persist `notes` when caching lectures.
- `lib/pages/lectures/lectures_page.dart` — pass `notes` to `Lecture`.
- `lib/pages/home/widgets/today_lectures.dart` — pass `notes` to `Lecture`.

## How to test

> Note: a re-sync is required after updating — the local cache must be refilled so the previously-null `notes` get repopulated.

1. Pull the branch, run the app, and trigger a data re-sync (pull-to-refresh / restart so it re-fetches from Supabase).
2. Open the **Classes** tab on a day with rector-day lectures (e.g. **5 June 2026** — many groups have `notes = "Dzień Rektorski"`).
3. Confirm those lectures are visually marked as rector day (not shown as normal lectures).
4. Check both the **Home** (today) and **Classes** views.
5. Sanity-check a normal lecture (empty notes) still renders normally.

Verified locally on the iOS simulator: rector-day lectures now display correctly after a re-sync; `flutter analyze` clean on all three files.
