### PR TITLE
fix(ci): repair the iOS deploy pipeline, release 1.2.2+26

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,11 +58,6 @@ jobs:
         run: |
           echo "${{ secrets.IOS_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
 
-      - name: Decode provisioning profile
-        working-directory: frontend/ios
-        run: |
-          echo "${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}" | base64 --decode > profile.mobileprovision
-
       - name: Install Ruby dependencies
         working-directory: frontend/ios
         run: bundle install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           channel: stable
 
+      # Runner.xcodeproj integrates plugins through CocoaPods and has no Swift
+      # package references. Newer Flutter releases enable Swift Package Manager
+      # by default, which routes SPM-capable plugins out of the Podfile and
+      # breaks the build with "Module 'app_links' not found".
+      - name: Disable Swift Package Manager plugin integration
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install Flutter dependencies
         working-directory: frontend
         run: flutter pub get

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 1.2.2
+
+### pl-PL
+
+- Nowy, skalowalny widżet planu zajęć na Androidzie
+- Zabezpieczono import planu i struktury uczelni przed utratą danych
+- Naprawiono przełączanie z wykładowcy na studenta i odświeżanie aktualności
+- Naprawiono plan na granicy miesiąca oraz widżet Android po północy
+- Aktualizacje aplikacji nie usuwają już zapisanego profilu
+- Ulepszono kontrole wersji i flag produkcyjnych w CI
+
+### en-US
+
+- New resizable Android schedule widget
+- Protected schedule and university structure imports against data loss
+- Fixed lecturer-to-student switching and news refresh
+- Fixed month-boundary schedules and the Android widget after midnight
+- App updates no longer remove the saved profile
+- Improved CI checks for versions and production flags
+
 ## 1.2.0
 
 ### pl-PL
@@ -79,20 +99,3 @@
 - First public beta release
 - Schedule browsing
 - Announcement notifications
-## 1.2.1
-
-### pl-PL
-
-- Zabezpieczono import planu i struktury uczelni przed utratą danych
-- Naprawiono przełączanie z wykładowcy na studenta i odświeżanie aktualności
-- Naprawiono plan na granicy miesiąca oraz widżet Android po północy
-- Aktualizacje aplikacji nie usuwają już zapisanego profilu
-- Ulepszono kontrole wersji i flag produkcyjnych w CI
-
-### en-US
-
-- Protected schedule and university structure imports against data loss
-- Fixed lecturer-to-student switching and news refresh
-- Fixed month-boundary schedules and the Android widget after midnight
-- App updates no longer remove the saved profile
-- Improved CI checks for versions and production flags

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 default_platform(:ios)
 
 def read_changelog_locale(version, locale)
@@ -17,7 +19,12 @@ platform :ios do
       key_content: ENV["APP_STORE_PRIVATE_KEY"],
     )
 
-    # Install certificate and provisioning profile in CI
+    # Let Xcode manage the App Group capability and the distribution profiles for
+    # the app + ScheduleWidget extension. A single manually installed profile
+    # cannot cover both bundle IDs, so signing stays automatic on CI too.
+    signing_xcargs = ["-allowProvisioningUpdates"]
+
+    # Install the distribution certificate in CI (profiles are fetched on the fly)
     if ENV["CI"]
       keychain_name = "ci_keychain"
       keychain_password = "ci_temp"
@@ -37,16 +44,22 @@ platform :ios do
         keychain_password: keychain_password,
       )
 
-      profile_path = install_provisioning_profile(path: "profile.mobileprovision")
-      profile_uuid = File.basename(profile_path, ".mobileprovision")
+      # `api_key` above only authorizes fastlane's own App Store Connect calls.
+      # xcodebuild needs the key on disk, otherwise -allowProvisioningUpdates
+      # falls back to Xcode's (nonexistent on CI) signed-in accounts.
+      key_id = ENV["APP_STORE_KEY_ID"]
+      key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
+      File.write(key_path, ENV["APP_STORE_PRIVATE_KEY"].gsub('\n', "\n"))
+      File.chmod(0600, key_path)
 
-      update_code_signing_settings(
-        use_automatic_signing: false,
-        path: "Runner.xcodeproj",
-        code_sign_identity: "Apple Distribution",
-        profile_uuid: profile_uuid,
-      )
+      signing_xcargs += [
+        "-authenticationKeyPath '#{key_path}'",
+        "-authenticationKeyID '#{key_id}'",
+        "-authenticationKeyIssuerID '#{ENV["APP_STORE_ISSUER_ID"]}'",
+      ]
     end
+
+    signing_xcargs = signing_xcargs.join(" ")
 
     # Read version + build number from pubspec.yaml
     pubspec = YAML.load_file("../../pubspec.yaml")
@@ -71,10 +84,8 @@ platform :ios do
       export_options: {
         signingStyle: "automatic",
       },
-      # Let Xcode register the App Group capability and create/update the
-      # distribution profiles for the app + ScheduleWidget extension on the fly
-      # (uses the admin App Store Connect API key configured above).
-      xcargs: "-allowProvisioningUpdates",
+      xcargs: signing_xcargs,
+      export_xcargs: signing_xcargs,
     )
 
     changelog = [

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -45,8 +45,11 @@ platform :ios do
       )
 
       # `api_key` above only authorizes fastlane's own App Store Connect calls.
-      # xcodebuild needs the key on disk, otherwise -allowProvisioningUpdates
-      # falls back to Xcode's (nonexistent on CI) signed-in accounts.
+      # The archive needs the key on disk as well, otherwise
+      # -allowProvisioningUpdates falls back to Xcode's (nonexistent on CI)
+      # signed-in accounts. gym injects these flags into the *export* command
+      # itself, so they must not be repeated there -- xcodebuild rejects
+      # -authenticationKeyPath when it is passed twice.
       key_id = ENV["APP_STORE_KEY_ID"]
       key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
       File.write(key_path, ENV["APP_STORE_PRIVATE_KEY"].gsub('\n', "\n"))
@@ -85,7 +88,6 @@ platform :ios do
         signingStyle: "automatic",
       },
       xcargs: signing_xcargs,
-      export_xcargs: signing_xcargs,
     )
 
     changelog = [

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.1+25
+version: 1.2.2+26
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary

The deploy workflow had been failing since the WidgetKit extension was added; the last green run was 1.1.1+21 on 6 May. What looked like one broken deploy was four stacked failures, each hidden behind the previous one. These commits are already on `deployment` and produced a green run for both platforms — 1.2.2+26 is on the Play production track and on TestFlight.

**1. iOS provisioning.** The `beta` lane forced manual code signing with a single App Store profile across all targets. That profile has no App Groups entitlement and its app ID cannot cover `...ScheduleWidget`, so the archive failed outright. Signing now stays automatic in CI, with the App Store Connect key passed to `xcodebuild` explicitly — fastlane's `api_key` only authorizes its own Spaceship calls, so `-allowProvisioningUpdates` had nothing to authenticate with on a runner without a signed-in Xcode account.

**2. Android version code.** Play rejected code 25, consumed earlier by a manual 1.2.0+25 upload. Bumped to 1.2.2+26; both members increase, as `version-check` requires.

**3. iOS plugin integration.** Flutter 3.44.8 on the runner enables Swift Package Manager by default, which routed 7 of 8 plugins out of the Podfile. `Runner.xcodeproj` has no Swift package references, so the archive failed with `Module 'app_links' not found`. Plugin integration is pinned back to CocoaPods.

**4. Duplicate export auth flags.** gym 2.237 injects `-allowProvisioningUpdates` and the `-authenticationKey*` flags into `-exportArchive` itself, so passing them via `export_xcargs` made `xcodebuild` fail with `option '-authenticationKeyPath' may only be provided once`. The archive command does not get them from gym, so `xcargs` still supplies them there.

Also moves the `1.2.1` changelog section, which sat at the end of the file with no separating blank line, to the top; renumbers it to `1.2.2` (1.2.1 never shipped to either store) and adds the resizable Android widget.

## Test plan

- Verified against real CI runs, not locally — the failures do not reproduce on a dev machine.
- Android: run 30250174201 — `Successfully finished the upload to Google Play`, track `production`, `release_status: completed`, changelogs uploaded for pl-PL and en-US.
- iOS: run 30251380864 — `Archive Succeeded`, `Successfully exported and signed the ipa file`, `Successfully finished processing the build 1.2.2 - 26`, `Successfully distributed build to Internal testers`.
- Changelog parsed through the actual `read_changelog_locale` helper: pl-PL 380 chars, en-US 341, both under the 500-char store limit.
- `version-check` and `changelog-check` simulated locally against `origin/deployment` before pushing.

## Out of scope

CI pins neither Flutter (`channel: stable`) nor fastlane (`frontend/ios/Gemfile.lock` is untracked), and this drift has now broken the deploy three times. Pinning is deliberately left out because the two pins are coupled to workarounds in this diff: committing `Gemfile.lock` at fastlane 2.232.2 would require restoring `export_xcargs`, reversing item 4. Worth doing as one deliberate change.

The secret `IOS_PROVISIONING_PROFILE_BASE64` is no longer referenced by any workflow and can be removed.